### PR TITLE
Add MemoryType::Custom(u32) variant

### DIFF
--- a/src/protocols/loaded_image.rs
+++ b/src/protocols/loaded_image.rs
@@ -29,8 +29,8 @@ pub struct Protocol {
 
     pub image_base: *mut core::ffi::c_void,
     pub image_size: u64,
-    pub image_code_type: crate::system::MemoryType,
-    pub image_data_type: crate::system::MemoryType,
+    pub image_code_type: u32,
+    pub image_data_type: u32,
     pub unload: eficall! {fn(
         crate::base::Handle,
     ) -> crate::base::Status},

--- a/src/system.rs
+++ b/src/system.rs
@@ -320,6 +320,25 @@ pub enum MemoryType {
     MemoryMappedIOPortSpace,
     PalCode,
     PersistentMemory,
+    MaxMemoryType,
+}
+
+impl Into<u32> for MemoryType {
+    fn into(self) -> u32 {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+
+impl core::convert::TryFrom<u32> for MemoryType {
+    type Error = ();
+
+    fn try_from(val: u32) -> Result<MemoryType, Self::Error> {
+        if val <= MemoryType::MaxMemoryType.into() {
+            unsafe { Ok(core::mem::transmute(val)) }
+        } else {
+            Err(())
+        }
+    }
 }
 
 pub const MEMORY_UC: u64 = 0x0000000000000001u64;

--- a/src/system.rs
+++ b/src/system.rs
@@ -582,7 +582,7 @@ pub struct BootServices {
 
     pub allocate_pages: eficall! {fn(
         AllocateType,
-        MemoryType,
+        u32,
         usize,
         *mut crate::base::PhysicalAddress,
     ) -> crate::base::Status},
@@ -598,7 +598,7 @@ pub struct BootServices {
         *mut u32,
     ) -> crate::base::Status},
     pub allocate_pool: eficall! {fn(
-        MemoryType,
+        u32,
         usize,
         *mut *mut core::ffi::c_void,
     ) -> crate::base::Status},


### PR DESCRIPTION
The EFI standard reserves the 0x70000000..0x7fffffff range for OEM use
and the 0x80000000..0xffffffff range for OS use. This establishes a way
to represent these valid values.

Signed-off-by: Richard Wiedenhöft <richard@wiedenhoeft.xyz>