### PR TITLE
r-efi: convert enums to constants

### DIFF
--- a/src/protocols/graphics_output.rs
+++ b/src/protocols/graphics_output.rs
@@ -21,15 +21,13 @@ pub struct PixelBitmask {
     pub reserved_mask: u32,
 }
 
-#[repr(C)]
-#[derive(Debug, Clone, Copy)]
-pub enum GraphicsPixelFormat {
-    PixelRedGreenBlueReserved8BitPerColor,
-    PixelBlueGreenRedReserved8BitPerColor,
-    PixelBitMask,
-    PixelBltOnly,
-    PixelFormatMax,
-}
+pub type GraphicsPixelFormat = u32;
+
+pub const PIXEL_RED_GREEN_BLUE_RESERVED_8_BIT_PER_COLOR: GraphicsPixelFormat = 0x00000000;
+pub const PIXEL_BLUE_GREEN_RED_RESERVED_8_BIT_PER_COLOR: GraphicsPixelFormat = 0x00000001;
+pub const PIXEL_BIT_MASK: GraphicsPixelFormat = 0x00000002;
+pub const PIXEL_BLT_ONLY: GraphicsPixelFormat = 0x00000003;
+pub const PIXEL_FORMAT_MAX: GraphicsPixelFormat = 0x00000004;
 
 #[repr(C)]
 #[derive(Debug, Clone, Copy)]
@@ -62,15 +60,13 @@ pub struct BltPixel {
     pub reserved: u8,
 }
 
-#[repr(C)]
-#[derive(Debug, Clone, Copy)]
-pub enum BltOperation {
-    BltVideoFill,
-    BltVideoToBltBuffer,
-    BltBufferToVideo,
-    BltVideoToVideo,
-    BltOperationMax,
-}
+pub type BltOperation = u32;
+
+pub const BLT_VIDEO_FILL: BltOperation = 0x00000000;
+pub const BLT_VIDEO_TO_BLT_BUFFER: BltOperation = 0x00000001;
+pub const BLT_BUFFER_TO_VIDEO: BltOperation = 0x00000002;
+pub const BLT_VIDEO_TO_VIDEO: BltOperation = 0x00000003;
+pub const BLT_OPERATION_MAX: BltOperation = 0x00000004;
 
 #[repr(C)]
 pub struct Protocol {

--- a/src/protocols/hii_database.rs
+++ b/src/protocols/hii_database.rs
@@ -110,115 +110,113 @@ pub const AFFECTED_BY_STANDARD_SHIFT: u16 = 0x0001;
 pub const AFFECTED_BY_CAPS_LOCK: u16 = 0x0002;
 pub const AFFECTED_BY_NUM_LOCK: u16 = 0x0004;
 
-#[repr(C)]
-#[derive(Debug, Clone, Copy)]
-pub enum Key {
-    EfiKeyLCtrl,
-    EfiKeyA0,
-    EfiKeyLAlt,
-    EfiKeySpaceBar,
-    EfiKeyA2,
-    EfiKeyA3,
-    EfiKeyA4,
-    EfiKeyRCtrl,
-    EfiKeyLeftArrow,
-    EfiKeyDownArrow,
-    EfiKeyRightArrow,
-    EfiKeyZero,
-    EfiKeyPeriod,
-    EfiKeyEnter,
-    EfiKeyLShift,
-    EfiKeyB0,
-    EfiKeyB1,
-    EfiKeyB2,
-    EfiKeyB3,
-    EfiKeyB4,
-    EfiKeyB5,
-    EfiKeyB6,
-    EfiKeyB7,
-    EfiKeyB8,
-    EfiKeyB9,
-    EfiKeyB10,
-    EfiKeyRShift,
-    EfiKeyUpArrow,
-    EfiKeyOne,
-    EfiKeyTwo,
-    EfiKeyThree,
-    EfiKeyCapsLock,
-    EfiKeyC1,
-    EfiKeyC2,
-    EfiKeyC3,
-    EfiKeyC4,
-    EfiKeyC5,
-    EfiKeyC6,
-    EfiKeyC7,
-    EfiKeyC8,
-    EfiKeyC9,
-    EfiKeyC10,
-    EfiKeyC11,
-    EfiKeyC12,
-    EfiKeyFour,
-    EfiKeyFive,
-    EfiKeySix,
-    EfiKeyPlus,
-    EfiKeyTab,
-    EfiKeyD1,
-    EfiKeyD2,
-    EfiKeyD3,
-    EfiKeyD4,
-    EfiKeyD5,
-    EfiKeyD6,
-    EfiKeyD7,
-    EfiKeyD8,
-    EfiKeyD9,
-    EfiKeyD10,
-    EfiKeyD11,
-    EfiKeyD12,
-    EfiKeyD13,
-    EfiKeyDel,
-    EfiKeyEnd,
-    EfiKeyPgDn,
-    EfiKeySeven,
-    EfiKeyEight,
-    EfiKeyNine,
-    EfiKeyE0,
-    EfiKeyE1,
-    EfiKeyE2,
-    EfiKeyE3,
-    EfiKeyE4,
-    EfiKeyE5,
-    EfiKeyE6,
-    EfiKeyE7,
-    EfiKeyE8,
-    EfiKeyE9,
-    EfiKeyE10,
-    EfiKeyE11,
-    EfiKeyE12,
-    EfiKeyBackSpace,
-    EfiKeyIns,
-    EfiKeyHome,
-    EfiKeyPgUp,
-    EfiKeyNLck,
-    EfiKeySlash,
-    EfiKeyAsterisk,
-    EfiKeyMinus,
-    EfiKeyEsc,
-    EfiKeyF1,
-    EfiKeyF2,
-    EfiKeyF3,
-    EfiKeyF4,
-    EfiKeyF5,
-    EfiKeyF6,
-    EfiKeyF7,
-    EfiKeyF8,
-    EfiKeyF9,
-    EfiKeyF10,
-    EfiKeyF11,
-    EfiKeyF12,
-    EfiKeyPrint,
-    EfiKeySLck,
-    EfiKeyPause,
-}
+pub type Key = u32;
+
+pub const EFI_KEY_LCTRL: Key = 0x00000000;
+pub const EFI_KEY_A0: Key = 0x00000001;
+pub const EFI_KEY_LALT: Key = 0x00000002;
+pub const EFI_KEY_SPACE_BAR: Key = 0x00000003;
+pub const EFI_KEY_A2: Key = 0x00000004;
+pub const EFI_KEY_A3: Key = 0x00000005;
+pub const EFI_KEY_A4: Key = 0x00000006;
+pub const EFI_KEY_RCTRL: Key = 0x00000007;
+pub const EFI_KEY_LEFT_ARROW: Key = 0x00000008;
+pub const EFI_KEY_DOWN_ARROW: Key = 0x00000009;
+pub const EFI_KEY_RIGHT_ARROW: Key = 0x0000000a;
+pub const EFI_KEY_ZERO: Key = 0x0000000b;
+pub const EFI_KEY_PERIOD: Key = 0x0000000c;
+pub const EFI_KEY_ENTER: Key = 0x0000000d;
+pub const EFI_KEY_LSHIFT: Key = 0x0000000e;
+pub const EFI_KEY_B0: Key = 0x0000000f;
+pub const EFI_KEY_B1: Key = 0x00000010;
+pub const EFI_KEY_B2: Key = 0x00000011;
+pub const EFI_KEY_B3: Key = 0x00000012;
+pub const EFI_KEY_B4: Key = 0x00000013;
+pub const EFI_KEY_B5: Key = 0x00000014;
+pub const EFI_KEY_B6: Key = 0x00000015;
+pub const EFI_KEY_B7: Key = 0x00000016;
+pub const EFI_KEY_B8: Key = 0x00000017;
+pub const EFI_KEY_B9: Key = 0x00000018;
+pub const EFI_KEY_B10: Key = 0x00000019;
+pub const EFI_KEY_RSHIFT: Key = 0x0000001a;
+pub const EFI_KEY_UP_ARROW: Key = 0x0000001b;
+pub const EFI_KEY_ONE: Key = 0x0000001c;
+pub const EFI_KEY_TWO: Key = 0x0000001d;
+pub const EFI_KEY_THREE: Key = 0x0000001e;
+pub const EFI_KEY_CAPS_LOCK: Key = 0x0000001f;
+pub const EFI_KEY_C1: Key = 0x00000020;
+pub const EFI_KEY_C2: Key = 0x00000021;
+pub const EFI_KEY_C3: Key = 0x00000022;
+pub const EFI_KEY_C4: Key = 0x00000023;
+pub const EFI_KEY_C5: Key = 0x00000024;
+pub const EFI_KEY_C6: Key = 0x00000025;
+pub const EFI_KEY_C7: Key = 0x00000026;
+pub const EFI_KEY_C8: Key = 0x00000027;
+pub const EFI_KEY_C9: Key = 0x00000028;
+pub const EFI_KEY_C10: Key = 0x00000029;
+pub const EFI_KEY_C11: Key = 0x0000002a;
+pub const EFI_KEY_C12: Key = 0x0000002b;
+pub const EFI_KEY_FOUR: Key = 0x0000002c;
+pub const EFI_KEY_FIVE: Key = 0x0000002d;
+pub const EFI_KEY_SIX: Key = 0x0000002e;
+pub const EFI_KEY_PLUS: Key = 0x0000002f;
+pub const EFI_KEY_TAB: Key = 0x00000030;
+pub const EFI_KEY_D1: Key = 0x00000031;
+pub const EFI_KEY_D2: Key = 0x00000032;
+pub const EFI_KEY_D3: Key = 0x00000033;
+pub const EFI_KEY_D4: Key = 0x00000034;
+pub const EFI_KEY_D5: Key = 0x00000035;
+pub const EFI_KEY_D6: Key = 0x00000036;
+pub const EFI_KEY_D7: Key = 0x00000037;
+pub const EFI_KEY_D8: Key = 0x00000038;
+pub const EFI_KEY_D9: Key = 0x00000039;
+pub const EFI_KEY_D10: Key = 0x0000003a;
+pub const EFI_KEY_D11: Key = 0x0000003b;
+pub const EFI_KEY_D12: Key = 0x0000003c;
+pub const EFI_KEY_D13: Key = 0x0000003d;
+pub const EFI_KEY_DEL: Key = 0x0000003e;
+pub const EFI_KEY_END: Key = 0x0000003f;
+pub const EFI_KEY_PGDN: Key = 0x00000040;
+pub const EFI_KEY_SEVEN: Key = 0x00000041;
+pub const EFI_KEY_EIGHT: Key = 0x00000042;
+pub const EFI_KEY_NINE: Key = 0x00000043;
+pub const EFI_KEY_E0: Key = 0x00000044;
+pub const EFI_KEY_E1: Key = 0x00000045;
+pub const EFI_KEY_E2: Key = 0x00000046;
+pub const EFI_KEY_E3: Key = 0x00000047;
+pub const EFI_KEY_E4: Key = 0x00000048;
+pub const EFI_KEY_E5: Key = 0x00000049;
+pub const EFI_KEY_E6: Key = 0x0000004a;
+pub const EFI_KEY_E7: Key = 0x0000004b;
+pub const EFI_KEY_E8: Key = 0x0000004c;
+pub const EFI_KEY_E9: Key = 0x0000004d;
+pub const EFI_KEY_E10: Key = 0x0000004e;
+pub const EFI_KEY_E11: Key = 0x0000004f;
+pub const EFI_KEY_E12: Key = 0x00000050;
+pub const EFI_KEY_BACK_SPACE: Key = 0x00000051;
+pub const EFI_KEY_INS: Key = 0x00000052;
+pub const EFI_KEY_HOME: Key = 0x00000053;
+pub const EFI_KEY_PGUP: Key = 0x00000054;
+pub const EFI_KEY_NLCK: Key = 0x00000055;
+pub const EFI_KEY_SLASH: Key = 0x00000056;
+pub const EFI_KEY_ASTERISK: Key = 0x00000057;
+pub const EFI_KEY_MINUS: Key = 0x00000058;
+pub const EFI_KEY_ESC: Key = 0x00000059;
+pub const EFI_KEY_F1: Key = 0x0000005a;
+pub const EFI_KEY_F2: Key = 0x0000005b;
+pub const EFI_KEY_F3: Key = 0x0000005c;
+pub const EFI_KEY_F4: Key = 0x0000005d;
+pub const EFI_KEY_F5: Key = 0x0000005e;
+pub const EFI_KEY_F6: Key = 0x0000005f;
+pub const EFI_KEY_F7: Key = 0x00000060;
+pub const EFI_KEY_F8: Key = 0x00000061;
+pub const EFI_KEY_F9: Key = 0x00000062;
+pub const EFI_KEY_F10: Key = 0x00000063;
+pub const EFI_KEY_F11: Key = 0x00000064;
+pub const EFI_KEY_F12: Key = 0x00000065;
+pub const EFI_KEY_PRINT: Key = 0x00000066;
+pub const EFI_KEY_SLCK: Key = 0x00000067;
+pub const EFI_KEY_PAUSE: Key = 0x00000068;
 
 pub const NULL_MODIFIER: u16 = 0x0000;
 pub const LEFT_CONTROL_MODIFIER: u16 = 0x0001;

--- a/src/protocols/simple_network.rs
+++ b/src/protocols/simple_network.rs
@@ -51,14 +51,12 @@ pub struct Mode {
     pub media_present: crate::base::Boolean,
 }
 
-#[repr(C)]
-#[derive(Debug, Clone, Copy)]
-pub enum NetworkState {
-    NetworkStopped,
-    NetworkStarted,
-    NetworkInitialized,
-    NetworkMaxState,
-}
+pub type NetworkState = u32;
+
+pub const NETWORK_STOPPED: NetworkState = 0x00000000;
+pub const NETWORK_STARTED: NetworkState = 0x00000001;
+pub const NETWORK_INITIALIZED: NetworkState = 0x00000002;
+pub const NETWORK_MAX_STATE: NetworkState = 0x00000003;
 
 #[repr(C)]
 #[derive(Debug, Clone, Copy)]

--- a/src/system.rs
+++ b/src/system.rs
@@ -130,14 +130,12 @@ pub const OPTIONAL_POINTER: u32 = 0x00000001u32;
 // different possible resets.
 //
 
-#[repr(C)]
-#[derive(Copy, Clone, Debug)]
-pub enum ResetType {
-    ResetCold,
-    ResetWarm,
-    ResetShutdown,
-    ResetPlatformSpecific,
-}
+pub type ResetType = u32;
+
+pub const RESET_COLD: ResetType = 0x00000000;
+pub const RESET_WARM: ResetType = 0x00000001;
+pub const RESET_SHUTDOWN: ResetType = 0x00000002;
+pub const RESET_PLATFORM_SPECIFIC: ResetType = 0x00000003;
 
 //
 // Update Capsules
@@ -272,13 +270,11 @@ pub const EVENT_GROUP_RESET_SYSTEM: crate::base::Guid = crate::base::Guid::from_
     &[0xa3, 0xdd, 0x79, 0x12, 0xcb, 0x6b],
 );
 
-#[repr(C)]
-#[derive(Copy, Clone, Debug)]
-pub enum TimerDelay {
-    TimerCancel,
-    TimerPeriodic,
-    TimerRelative,
-}
+pub type TimerDelay = u32;
+
+pub const TIMER_CANCEL: TimerDelay = 0x00000000;
+pub const TIMER_PERIODIC: TimerDelay = 0x00000001;
+pub const TIMER_RELATIVE: TimerDelay = 0x00000002;
 
 pub const TPL_APPLICATION: crate::base::Tpl = 4;
 pub const TPL_CALLBACK: crate::base::Tpl = 8;
@@ -294,33 +290,29 @@ pub const TPL_HIGH_LEVEL: crate::base::Tpl = 31;
 // dynamic modifications can be done once you exit boot services.
 //
 
-#[repr(C)]
-#[derive(Copy, Clone, Debug)]
-pub enum AllocateType {
-    AllocateAnyPages,
-    AllocateMaxAddress,
-    AllocateAddress,
-}
+pub type AllocateType = u32;
 
-#[repr(C)]
-#[derive(Copy, Clone, Debug)]
-pub enum MemoryType {
-    ReservedMemoryType,
-    LoaderCode,
-    LoaderData,
-    BootServicesCode,
-    BootServicesData,
-    RuntimeServicesCode,
-    RuntimeServicesData,
-    ConventionalMemory,
-    UnusableMemory,
-    AcpiReclaimMemory,
-    AcpiMemoryNvs,
-    MemoryMappedIO,
-    MemoryMappedIOPortSpace,
-    PalCode,
-    PersistentMemory,
-}
+pub const ALLOCATE_ANY_PAGES: AllocateType = 0x00000000;
+pub const ALLOCATE_MAX_ADDRESS: AllocateType = 0x00000001;
+pub const ALLOCATE_ADDRESS: AllocateType = 0x00000002;
+
+pub type MemoryType = u32;
+
+pub const RESERVED_MEMORY_TYPE: MemoryType = 0x00000000;
+pub const LOADER_CODE: MemoryType = 0x00000001;
+pub const LOADER_DATA: MemoryType = 0x00000002;
+pub const BOOT_SERVICES_CODE: MemoryType = 0x00000003;
+pub const BOOT_SERVICES_DATA: MemoryType = 0x00000004;
+pub const RUNTIME_SERVICES_CODE: MemoryType = 0x00000005;
+pub const RUNTIME_SERVICES_DATA: MemoryType = 0x00000006;
+pub const CONVENTIONAL_MEMORY: MemoryType = 0x00000007;
+pub const UNUSABLE_MEMORY: MemoryType = 0x00000008;
+pub const ACPI_RECLAIM_MEMORY: MemoryType = 0x00000009;
+pub const ACPI_MEMORY_NVS: MemoryType = 0x0000000a;
+pub const MEMORY_MAPPED_IO: MemoryType = 0x0000000b;
+pub const MEMORY_MAPPED_IO_PORT_SPACE: MemoryType = 0x0000000c;
+pub const PAL_CODE: MemoryType = 0x0000000d;
+pub const PERSISTENT_MEMORY: MemoryType = 0x0000000e;
 
 pub const MEMORY_UC: u64 = 0x0000000000000001u64;
 pub const MEMORY_WC: u64 = 0x0000000000000002u64;
@@ -356,19 +348,15 @@ pub struct MemoryDescriptor {
 // hotplugging.
 //
 
-#[repr(C)]
-#[derive(Copy, Clone, Debug)]
-pub enum InterfaceType {
-    NativeInterface,
-}
+pub type InterfaceType = u32;
 
-#[repr(C)]
-#[derive(Copy, Clone, Debug)]
-pub enum LocateSearchType {
-    AllHandles,
-    ByRegisterNotify,
-    ByProtocol,
-}
+pub const NATIVE_INTERFACE: InterfaceType = 0x00000000;
+
+pub type LocateSearchType = u32;
+
+pub const ALL_HANDLES: LocateSearchType = 0x00000000;
+pub const BY_REGISTER_NOTIFY: LocateSearchType = 0x00000001;
+pub const BY_PROTOCOL: LocateSearchType = 0x00000002;
 
 pub const OPEN_PROTOCOL_BY_HANDLE_PROTOCOL: u32 = 0x00000001u32;
 pub const OPEN_PROTOCOL_GET_PROTOCOL: u32 = 0x00000002u32;
@@ -825,36 +813,4 @@ pub struct SystemTable {
 
     pub number_of_table_entries: usize,
     pub configuration_table: *mut ConfigurationTable,
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    // Verify ABI of MemoryType
-    //
-    // The MemoryType implementation cannot perfectly mirror the UEFI
-    // specification, as rust does not allow enum discriminants outside the
-    // declared range. This test verifies the ABI of MemoryType matches our
-    // expectations, and the converters are correctly implemented.
-    //
-    // In particular, MemoryType reserves all values with the MSB set for
-    // platform and implementation purposes. We cannot define all those enum
-    // variants, so we must use `u32` wherever we accept MemoryType values.
-    // We therefore verify that `v as u32` conversions are valid and properly
-    // defined.
-    #[test]
-    fn memory_type_abi() {
-        assert_eq!(
-            std::mem::size_of::<MemoryType>(),
-            std::mem::size_of::<u32>(),
-        );
-        assert_eq!(
-            std::mem::align_of::<MemoryType>(),
-            std::mem::align_of::<u32>(),
-        );
-
-        assert_eq!(MemoryType::ReservedMemoryType as u32, 0);
-        assert_eq!(MemoryType::PersistentMemory as u32, 14);
-    }
 }


### PR DESCRIPTION
(Cc: @Richard-W)

This converts all `enum` types to `i32/u32` aliases with their variants
as constants. This is an API break, but the ABI stays unchanged.

The UEFI specification defines some enums that combine classic
enumerations with flags. One example is `MemoryType`, which reserves a
high-range with the MSB set for platform-specific types. With our
current implementation, we cannot reasonably represent those. Rust does
not allow undefined discrimants even for `repr(C)` enums. At the same
time, we cannot reasonable define an enum variant for all 2 billion
reserved identifiers.

Note that the UEFI specification is very clear on the ABI:

    Element of a standard ANSI C enum type declaration. Type INT32 or
    UINT32.  ANSI C does not define the size of sign of an enum so they
    should never be used in structures. ANSI C integer promotion rules
    make INT32 or UINT32 interchangeable when passed as an argument to
    a function.

Therefore, all enums should use a 32-bit underlying type and never be
used for structures. Promotion rules also guarantee that they are passed
as u32 to functions, so no worries there. For all intents and purposes,
we can thus treat them as `u32`.

There is one problem where the specification would extend an existing
structure with a negative variant, thus causing the underlying type to
switch to `i32`. With an `repr(C)`-enum (or with a C enum), this would
not be an API break, but it would be an API break if we use `u32`.
However, this sounds highly unlikely to happen, and even then would only
be a minor inconvenience. Even the type-change in a `repr(C)`-enum (and
more importantly in a C enum) would be a major nuissance and likely
break assumptions of existing applications. So we do not expect this to
happen.

Now there is several ways to transpose the C enums into Rust, each with
up- and downsides:

 * enum: By using rust enums, we get more type-safety, while retaining
   the possibility to extend the type with our own helpers. This allows
   to `match` on an enum and get completeness-checks by the compiler.
   Furthermore, enums and integers cannot be mixed up unintentionally.
   The downside are the aforementioned problems of flags mixed in an
   enum. We would be forced to use `u32` in all function-definitions
   where the enum-type is expected, otherwise users would be unable to
   pass the right values. An alternative is to provide additional `*Raw`
   function calls alongside the typed-ones, which use `u32`.
   Using `u32` in function definitions is likely to trip us in the
   future when we forget this when transposing new data from the spec.
   At the same time, it requires every caller to convert the enum to an
   u32 at the call-site, which just feels like a mismatch.

 * newtype: By using the newtype-idiom we could wrap a u32 into a
   structure and put `repr(transparent)` on it. This would gives us free
   hands at properly wrapping every type, but it would require lots of
   policy decisions and feels out-of-scope of this project. It would no
   longer be a straightforward transpose of the specification.

 * alias: By aliasing these types as `u32` we get a straightforward
   transpose from the spec, and direct mapping to the C behavior.
   However, it is the least ergonomic solution and provides no real
   benefits over C.

This patch chooses the `alias` option and removes all Rust `enum`s from
the code-base. The reason for this is that the UEFI specification itself
chose this option for a lot of the newer protocols. It avoids all the
ABI nastiness around enums and easy extensions in the future.

With the nature of this project in mind, it seems to be the right
solution to provide the raw constants with a clear and simple mapping
from the spec, rather than the more ergonomic solutions. Higher-level
crates are likely to wrap every single lower type, anyway. And with this
solution, they retain the full freedom to do this, while we take care of
transposing the spec and guaranteeing correctness of the underlying
values, and monitoring the spec for changes.

Thanks to Richard for reporting the issue and evaluating different
options how to solve this!