### PR TITLE
Derive Default for Time

### DIFF
--- a/src/system.rs
+++ b/src/system.rs
@@ -23,7 +23,7 @@ pub const UNSPECIFIED_TIMEZONE: i16 = 0x07ffi16;
 
 // Cannot derive `Eq` etc. due to uninitialized `pad2` field.
 #[repr(C)]
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct Time {
     pub year: u16,
     pub month: u8,


### PR DESCRIPTION
Time cannot be a null pointer when passing to GetTime. Thus there needs
to be a default initialization.

Signed-off-by: Ayush Singh <ayushsingh1325@gmail.com>