### PR TITLE
Make NotifyFunction Optional

### DIFF
--- a/src/system.rs
+++ b/src/system.rs
@@ -610,7 +610,7 @@ pub type BootFreePool = eficall! {fn(
 pub type BootCreateEvent = eficall! {fn(
     u32,
     crate::base::Tpl,
-    EventNotify,
+    Option<EventNotify>,
     *mut core::ffi::c_void,
     *mut crate::base::Event,
 ) -> crate::base::Status};
@@ -827,7 +827,7 @@ pub type BootSetMem = eficall! {fn(
 pub type BootCreateEventEx = eficall! {fn(
     u32,
     crate::base::Tpl,
-    EventNotify,
+    Option<EventNotify>,
     *const core::ffi::c_void,
     *const crate::base::Guid,
     *mut crate::base::Event,


### PR DESCRIPTION
Rust uses `Option<fn ..>` to represent [Nullable Function pointer](https://rust-lang.github.io/unsafe-code-guidelines/layout/function-pointers.html). It will have the same exact ABI (according to the docs I linked above) as a `fn ..` but will allow null.

This is needed since the `NotifyFunction` parameter is Optional.

It might be a good idea to check what other Function pointers should be represented in this way.

Signed-off-by: Ayush Singh <ayushsingh1325@gmail.com>