### PR TITLE
lib: document nullable function pointers

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,6 +63,13 @@
 //!    As a workaround, trailing unbound arrays are transposed as zero-sized
 //!    arrays for now.
 //!
+//!  * `nullable callbacks as Option`: Rust has no raw function pointers, but
+//!    just normal Rust function pointers. Those, however, have no valid null
+//!    value. The Rust ABI guarantees that `Option<fn ...>` is an C-ABI
+//!    compatible replacement for nullable function pointers, with `None` being
+//!    mapped to `NULL`. Hence, whenever UEFI APIs require nullable function
+//!    pointers, we use `Option<fn ...>`.
+//!
 //! # Examples
 //!
 //! To write free-standing UEFI applications, you need to disable the entry-point provided by rust


### PR DESCRIPTION
Document our translation strategy for nullable function pointers.
Whenever the spec requires them, we map them to `Option<fn ...>`, and
Rust guarantees that the ABI is compatible [1].

[1] https://rust-lang.github.io/unsafe-code-guidelines/layout/function-pointers.html

Reported-by: Ayush Singh <ayushsingh1325@gmail.com>
Signed-off-by: David Rheinsberg <david.rheinsberg@gmail.com>
Cc: @Ayush1325 