### PR TITLE
Make RNG protocol members public

### DIFF
--- a/src/protocols/rng.rs
+++ b/src/protocols/rng.rs
@@ -78,6 +78,6 @@ pub type ProtocolGetRng = eficall! {fn(
 
 #[repr(C)]
 pub struct Protocol {
-    get_info: ProtocolGetInfo,
-    get_rng: ProtocolGetRng,
+    pub get_info: ProtocolGetInfo,
+    pub get_rng: ProtocolGetRng,
 }


### PR DESCRIPTION
The RNG protocol members are private. So fixing that.

This should be merged before #47 .

Signed-off-by: Ayush <ayushsingh1325@gmail.com>