### PR TITLE
Implement Default for tcp4::ConfigData

### DIFF
--- a/src/base.rs
+++ b/src/base.rs
@@ -455,7 +455,7 @@ pub struct MacAddress {
 /// order (i.e., big endian). Note that no special alignment restrictions are
 /// defined by the standard specification.
 #[repr(C)]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Default)]
 pub struct Ipv4Address {
     pub addr: [u8; 4],
 }
@@ -508,6 +508,12 @@ impl From<bool> for Boolean {
             false => Boolean::FALSE,
             true => Boolean::TRUE,
         }
+    }
+}
+
+impl Default for Boolean {
+    fn default() -> Self {
+        Self::FALSE
     }
 }
 

--- a/src/protocols/tcp4.rs
+++ b/src/protocols/tcp4.rs
@@ -43,8 +43,19 @@ pub struct ConfigData {
     pub control_option: *mut r#Option,
 }
 
+impl Default for ConfigData {
+    fn default() -> Self {
+        Self {
+            type_of_service: Default::default(),
+            time_to_live: Default::default(),
+            access_point: Default::default(),
+            control_option: core::ptr::null_mut(),
+        }
+    }
+}
+
 #[repr(C)]
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct AccessPoint {
     pub use_default_address: crate::base::Boolean,
     pub station_address: crate::base::Ipv4Address,


### PR DESCRIPTION
Passing unint data to `EFI_TCP4_PROTOCOL.GetModeData()` causes UB.
Passing `MaybeUnint::zeroed()` works fine though.

Not sure if this is the intended behavior or a bug in OVMF.

Signed-off-by: Ayush <ayushsingh1325@gmail.com>