### PR TITLE
Convert ZST to const-generics

### DIFF
--- a/src/hii.rs
+++ b/src/hii.rs
@@ -18,10 +18,10 @@ pub type Handle = *mut core::ffi::c_void;
 
 #[repr(C)]
 #[derive(Clone, Copy, Debug)]
-pub struct PackageHeader {
+pub struct PackageHeader<const N: usize = 0> {
     pub length: [u8; 3],
     pub r#type: u8,
-    pub data: [u8; 0],
+    pub data: [u8; N],
 }
 
 pub const PACKAGE_TYPE_ALL: u8 = 0x00;
@@ -51,13 +51,13 @@ pub struct PackageListHeader {
 
 #[repr(C)]
 #[derive(Clone, Copy, Debug)]
-pub struct FontPackageHdr {
+pub struct FontPackageHdr<const N: usize = 0> {
     pub header: PackageHeader,
     pub hdr_size: u32,
     pub glyph_block_offset: u32,
     pub cell: GlyphInfo,
     pub font_style: FontStyle,
-    pub font_family: [crate::base::Char16; 0],
+    pub font_family: [crate::base::Char16; N],
 }
 
 pub type FontStyle = u32;
@@ -73,9 +73,9 @@ pub const FONT_STYLE_DBL_UNDER: FontStyle = 0x00100000;
 
 #[repr(C)]
 #[derive(Clone, Copy, Debug)]
-pub struct GlyphBlock {
+pub struct GlyphBlock<const N: usize = 0> {
     pub block_type: u8,
-    pub block_body: [u8; 0],
+    pub block_body: [u8; N],
 }
 
 pub const GIBT_END: u8 = 0x00;
@@ -148,34 +148,34 @@ pub struct GibtExt4Block {
 
 #[repr(C)]
 #[derive(Clone, Copy, Debug)]
-pub struct GibtGlyphBlock {
+pub struct GibtGlyphBlock<const N: usize = 0> {
     pub header: GlyphBlock,
     pub cell: GlyphInfo,
-    pub bitmap_data: [u8; 0],
+    pub bitmap_data: [u8; N],
 }
 
 #[repr(C)]
 #[derive(Clone, Copy, Debug)]
-pub struct GibtGlyphsBlock {
+pub struct GibtGlyphsBlock<const N: usize = 0> {
     pub header: GlyphBlock,
     pub cell: GlyphInfo,
     pub count: u16,
-    pub bitmap_data: [u8; 0],
+    pub bitmap_data: [u8; N],
 }
 
 #[repr(C)]
 #[derive(Clone, Copy, Debug)]
-pub struct GibtGlyphDefaultBlock {
+pub struct GibtGlyphDefaultBlock<const N: usize = 0> {
     pub header: GlyphBlock,
-    pub bitmap_data: [u8; 0],
+    pub bitmap_data: [u8; N],
 }
 
 #[repr(C)]
 #[derive(Clone, Copy, Debug)]
-pub struct GibtGlypshDefaultBlock {
+pub struct GibtGlypshDefaultBlock<const N: usize = 0> {
     pub header: GlyphBlock,
     pub count: u16,
-    pub bitmap_data: [u8; 0],
+    pub bitmap_data: [u8; N],
 }
 
 #[repr(C)]
@@ -194,11 +194,11 @@ pub struct GibtSkip1Block {
 
 #[repr(C)]
 #[derive(Clone, Copy, Debug)]
-pub struct GibtVariabilityBlock {
+pub struct GibtVariabilityBlock<const N: usize = 0> {
     pub header: GlyphBlock,
     pub cell: GlyphInfo,
     pub glyph_pack_in_bits: u8,
-    pub bitmap_data: [u8; 0],
+    pub bitmap_data: [u8; N],
 }
 
 //
@@ -516,11 +516,11 @@ pub struct IfrEqIdId {
 
 #[repr(C)]
 #[derive(Clone, Copy, Debug)]
-pub struct IfrEqIdValList {
+pub struct IfrEqIdValList<const N: usize = 0> {
     pub header: IfrOpHeader,
     pub question_id: QuestionId,
     pub list_length: u16,
-    pub value_list: [u16; 0],
+    pub value_list: [u16; N],
 }
 
 #[repr(C)]
@@ -564,10 +564,10 @@ pub struct IfrFormMapMethod {
 
 #[repr(C)]
 #[derive(Clone, Copy, Debug)]
-pub struct IfrFormMap {
+pub struct IfrFormMap<const N: usize = 0> {
     pub header: IfrOpHeader,
     pub form_id: FormId,
-    pub methods: [IfrFormMapMethod; 0],
+    pub methods: [IfrFormMapMethod; N],
 }
 
 pub const STANDARD_FORM_GUID: crate::base::Guid = crate::base::Guid::from_fields(
@@ -581,13 +581,13 @@ pub const STANDARD_FORM_GUID: crate::base::Guid = crate::base::Guid::from_fields
 
 #[repr(C)]
 #[derive(Clone, Copy, Debug)]
-pub struct IfrFormSet {
+pub struct IfrFormSet<const N: usize = 0> {
     pub header: IfrOpHeader,
     pub guid: crate::base::Guid,
     pub form_set_title: StringId,
     pub help: StringId,
     pub flags: u8,
-    pub class_guid: [crate::base::Guid; 0],
+    pub class_guid: [crate::base::Guid; N],
 }
 
 #[repr(C)]
@@ -819,7 +819,7 @@ pub struct IfrOneOfOption {
 
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub union IfrTypeValue {
+pub union IfrTypeValue<const N: usize = 0> {
     pub r#u8: u8,
     pub r#u16: u16,
     pub r#u32: u32,
@@ -829,7 +829,7 @@ pub union IfrTypeValue {
     pub date: Date,
     pub string: StringId,
     pub r#ref: Ref,
-    pub buffer: [u8; 0],
+    pub buffer: [u8; N],
 }
 
 #[repr(C)]
@@ -1232,12 +1232,12 @@ pub struct IfrValue {
 
 #[repr(C)]
 #[derive(Clone, Copy, Debug)]
-pub struct IfrVarstore {
+pub struct IfrVarstore<const N: usize = 0> {
     pub header: IfrOpHeader,
     pub guid: crate::base::Guid,
     pub var_store_id: VarstoreId,
     pub size: u16,
-    pub name: [u8; 0],
+    pub name: [u8; N],
 }
 
 #[repr(C)]
@@ -1250,13 +1250,13 @@ pub struct IfrVarstoreNameValue {
 
 #[repr(C)]
 #[derive(Clone, Copy, Debug)]
-pub struct IfrVarstoreEfi {
+pub struct IfrVarstoreEfi<const N: usize = 0> {
     pub header: IfrOpHeader,
     pub var_store_id: VarstoreId,
     pub guid: crate::base::Guid,
     pub attributes: u32,
     pub size: u16,
-    pub name: [u8; 0],
+    pub name: [u8; N],
 }
 
 #[repr(C)]

--- a/src/protocols/file.rs
+++ b/src/protocols/file.rs
@@ -55,7 +55,7 @@ pub struct IoToken {
 
 #[repr(C)]
 #[derive(Clone, Copy, Debug)]
-pub struct Info {
+pub struct Info<const N: usize = 0> {
     pub size: u64,
     pub file_size: u64,
     pub physical_size: u64,
@@ -63,24 +63,24 @@ pub struct Info {
     pub last_access_time: crate::system::Time,
     pub modification_time: crate::system::Time,
     pub attribute: u64,
-    pub file_name: [crate::base::Char16; 0],
+    pub file_name: [crate::base::Char16; N],
 }
 
 #[repr(C)]
 #[derive(Clone, Copy, Debug)]
-pub struct SystemInfo {
+pub struct SystemInfo<const N: usize = 0> {
     pub size: u64,
     pub read_only: crate::base::Boolean,
     pub volume_size: u64,
     pub free_space: u64,
     pub block_size: u32,
-    pub volume_label: [crate::base::Char16; 0],
+    pub volume_label: [crate::base::Char16; N],
 }
 
 #[repr(C)]
 #[derive(Clone, Copy, Debug)]
-pub struct SystemVolumeLabel {
-    pub volume_label: [crate::base::Char16; 0],
+pub struct SystemVolumeLabel<const N: usize = 0> {
+    pub volume_label: [crate::base::Char16; N],
 }
 
 pub type ProtocolOpen = eficall! {fn(

--- a/src/protocols/hii_database.rs
+++ b/src/protocols/hii_database.rs
@@ -108,12 +108,12 @@ pub struct Protocol {
 
 #[repr(C)]
 #[derive(Clone, Copy, Debug)]
-pub struct KeyboardLayout {
+pub struct KeyboardLayout<const N: usize = 0> {
     pub layout_length: u16,
     pub guid: crate::base::Guid,
     pub layout_descriptor_string_offset: u32,
     pub descriptor_count: u8,
-    pub descriptors: [KeyDescriptor; 0],
+    pub descriptors: [KeyDescriptor; N],
 }
 
 #[repr(C)]

--- a/src/protocols/hii_string.rs
+++ b/src/protocols/hii_string.rs
@@ -64,8 +64,8 @@ pub struct Protocol {
 
 #[repr(C)]
 #[derive(Clone, Copy, Debug)]
-pub struct Info {
+pub struct Info<const N: usize = 0> {
     pub font_style: crate::hii::FontStyle,
     pub font_size: u16,
-    pub font_name: [crate::base::Char16; 0],
+    pub font_name: [crate::base::Char16; N],
 }

--- a/src/protocols/ip4.rs
+++ b/src/protocols/ip4.rs
@@ -87,7 +87,7 @@ pub union CompletionTokenPacket {
 
 #[repr(C)]
 #[derive(Clone, Copy, Debug)]
-pub struct ReceiveData {
+pub struct ReceiveData<const N: usize = 0> {
     pub time_stamp: crate::system::Time,
     pub recycle_signal: crate::base::Event,
     pub header_length: u32,
@@ -96,19 +96,19 @@ pub struct ReceiveData {
     pub options: *mut core::ffi::c_void,
     pub data_length: u32,
     pub fragment_count: u32,
-    pub fragment_table: [FragmentData; 0],
+    pub fragment_table: [FragmentData; N],
 }
 
 #[repr(C)]
 #[derive(Clone, Copy, Debug)]
-pub struct TransmitData {
+pub struct TransmitData<const N: usize = 0> {
     pub destination_address: crate::base::Ipv4Address,
     pub override_data: *mut OverrideData,
     pub options_length: u32,
     pub options_buffer: *mut core::ffi::c_void,
     pub total_data_length: u32,
     pub fragment_count: u32,
-    pub fragment_table: [FragmentData; 0],
+    pub fragment_table: [FragmentData; N],
 }
 
 #[repr(C)]

--- a/src/protocols/ip6.rs
+++ b/src/protocols/ip6.rs
@@ -145,14 +145,14 @@ pub union CompletionTokenPacket {
 
 #[repr(C)]
 #[derive(Clone, Copy, Debug)]
-pub struct ReceiveData {
+pub struct ReceiveData<const N: usize = 0> {
     pub time_stamp: crate::system::Time,
     pub recycle_signal: crate::base::Event,
     pub header_length: u32,
     pub header: *mut Header,
     pub data_length: u32,
     pub fragment_count: u32,
-    pub fragment_table: [FragmentData; 0],
+    pub fragment_table: [FragmentData; N],
 }
 
 #[repr(C)]
@@ -177,7 +177,7 @@ pub struct FragmentData {
 
 #[repr(C)]
 #[derive(Clone, Copy, Debug)]
-pub struct TransmitData {
+pub struct TransmitData<const N: usize = 0> {
     pub destination_address: *mut crate::base::Ipv6Address,
     pub override_data: *mut OverrideData,
     pub ext_hdrs_length: u32,
@@ -185,7 +185,7 @@ pub struct TransmitData {
     pub next_header: u8,
     pub data_length: u32,
     pub fragment_count: u32,
-    pub fragment_table: [FragmentData; 0],
+    pub fragment_table: [FragmentData; N],
 }
 
 #[repr(C)]

--- a/src/protocols/managed_network.rs
+++ b/src/protocols/managed_network.rs
@@ -74,14 +74,14 @@ pub struct ReceiveData {
 
 #[repr(C)]
 #[derive(Clone, Copy, Debug)]
-pub struct TransmitData {
+pub struct TransmitData<const N: usize = 0> {
     pub destination_address: *mut crate::base::MacAddress,
     pub source_address: *mut crate::base::MacAddress,
     pub protocol_type: u16,
     pub data_length: u32,
     pub header_length: u16,
     pub fragment_count: u16,
-    pub fragment_table: [FragmentData; 0],
+    pub fragment_table: [FragmentData; N],
 }
 
 #[repr(C)]

--- a/src/protocols/tcp4.rs
+++ b/src/protocols/tcp4.rs
@@ -122,11 +122,11 @@ pub union IoTokenPacket {
 
 #[repr(C)]
 #[derive(Clone, Copy, Debug)]
-pub struct ReceiveData {
+pub struct ReceiveData<const N: usize = 0> {
     pub urgent_flag: crate::base::Boolean,
     pub data_length: u32,
     pub fragment_count: u32,
-    pub fragment_table: [FragmentData; 0],
+    pub fragment_table: [FragmentData; N],
 }
 
 #[repr(C)]
@@ -138,12 +138,12 @@ pub struct FragmentData {
 
 #[repr(C)]
 #[derive(Clone, Copy, Debug)]
-pub struct TransmitData {
+pub struct TransmitData<const N: usize = 0> {
     pub push: crate::base::Boolean,
     pub urgent: crate::base::Boolean,
     pub data_length: u32,
     pub fragment_count: u32,
-    pub fragment_table: [FragmentData; 0],
+    pub fragment_table: [FragmentData; N],
 }
 
 #[repr(C)]

--- a/src/protocols/tcp6.rs
+++ b/src/protocols/tcp6.rs
@@ -109,11 +109,11 @@ pub union IoTokenPacket {
 
 #[repr(C)]
 #[derive(Clone, Copy, Debug)]
-pub struct ReceiveData {
+pub struct ReceiveData<const N: usize = 0> {
     pub urgent_flag: crate::base::Boolean,
     pub data_length: u32,
     pub fragment_count: u32,
-    pub fragment_table: [FragmentData; 0],
+    pub fragment_table: [FragmentData; N],
 }
 
 #[repr(C)]
@@ -125,12 +125,12 @@ pub struct FragmentData {
 
 #[repr(C)]
 #[derive(Clone, Copy, Debug)]
-pub struct TransmitData {
+pub struct TransmitData<const N: usize = 0> {
     pub push: crate::base::Boolean,
     pub urgent: crate::base::Boolean,
     pub data_length: u32,
     pub fragment_count: u32,
-    pub fragment_table: [FragmentData; 0],
+    pub fragment_table: [FragmentData; N],
 }
 
 #[repr(C)]

--- a/src/protocols/udp4.rs
+++ b/src/protocols/udp4.rs
@@ -58,23 +58,23 @@ pub struct FragmentData {
 
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct ReceiveData {
+pub struct ReceiveData<const N: usize = 0> {
     pub time_stamp: crate::system::Time,
     pub recycle_signal: crate::base::Event,
     pub udp_session: SessionData,
     pub data_length: u32,
     pub fragment_count: u32,
-    pub fragment_table: [FragmentData; 0],
+    pub fragment_table: [FragmentData; N],
 }
 
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct TransmitData {
+pub struct TransmitData<const N: usize = 0> {
     pub udp_session_data: *mut SessionData,
     pub gateway_address: *mut crate::base::Ipv4Address,
     pub data_length: u32,
     pub fragment_count: u32,
-    pub fragment_table: [FragmentData; 0],
+    pub fragment_table: [FragmentData; N],
 }
 
 #[repr(C)]

--- a/src/protocols/udp6.rs
+++ b/src/protocols/udp6.rs
@@ -54,22 +54,22 @@ pub struct FragmentData {
 
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct ReceiveData {
+pub struct ReceiveData<const N: usize = 0> {
     pub time_stamp: crate::system::Time,
     pub recycle_signal: crate::base::Event,
     pub udp_session: SessionData,
     pub data_length: u32,
     pub fragment_count: u32,
-    pub fragment_table: [FragmentData; 0],
+    pub fragment_table: [FragmentData; N],
 }
 
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct TransmitData {
+pub struct TransmitData<const N: usize = 0> {
     pub udp_session_data: *mut SessionData,
     pub data_length: u32,
     pub fragment_count: u32,
-    pub fragment_table: [FragmentData; 0],
+    pub fragment_table: [FragmentData; N],
 }
 
 #[repr(C)]

--- a/src/system.rs
+++ b/src/system.rs
@@ -66,24 +66,24 @@ pub const VARIABLE_AUTHENTICATION_3_CERT_ID_SHA256: u32 = 0x1u32;
 
 #[repr(C)]
 #[derive(Clone, Copy, Debug)]
-pub struct VariableAuthentication3CertId {
+pub struct VariableAuthentication3CertId<const N: usize = 0> {
     pub r#type: u8,
     pub id_size: u32,
-    pub id: [u8; 0],
+    pub id: [u8; N],
 }
 
 #[repr(C)]
 #[derive(Clone, Copy, Debug)]
-pub struct VariableAuthentication {
+pub struct VariableAuthentication<const N: usize = 0> {
     pub monotonic_count: u64,
-    pub auth_info: [u8; 0], // WIN_CERTIFICATE_UEFI_ID from PE/COFF
+    pub auth_info: [u8; N], // WIN_CERTIFICATE_UEFI_ID from PE/COFF
 }
 
 #[repr(C)]
 #[derive(Clone, Copy, Debug)]
-pub struct VariableAuthentication2 {
+pub struct VariableAuthentication2<const N: usize = 0> {
     pub timestamp: Time,
-    pub auth_info: [u8; 0], // WIN_CERTIFICATE_UEFI_ID from PE/COFF
+    pub auth_info: [u8; N], // WIN_CERTIFICATE_UEFI_ID from PE/COFF
 }
 
 pub const VARIABLE_AUTHENTICATION_3_TIMESTAMP_TYPE: u32 = 0x1u32;
@@ -100,9 +100,9 @@ pub struct VariableAuthentication3 {
 
 #[repr(C)]
 #[derive(Clone, Copy, Debug)]
-pub struct VariableAuthentication3Nonce {
+pub struct VariableAuthentication3Nonce<const N: usize = 0> {
     pub nonce_size: u32,
-    pub nonce: [u8; 0],
+    pub nonce: [u8; N],
 }
 
 pub const HARDWARE_ERROR_VARIABLE_GUID: crate::base::Guid = crate::base::Guid::from_fields(
@@ -201,12 +201,12 @@ pub struct CapsuleResultVariableHeader {
 
 #[repr(C)]
 #[derive(Clone, Copy, Debug)]
-pub struct CapsuleResultVariableFMP {
+pub struct CapsuleResultVariableFMP<const N: usize = 0> {
     pub version: u16,
     pub payload_index: u8,
     pub update_image_index: u8,
     pub update_image_type_id: crate::base::Guid,
-    pub capsule_file_name_and_target: [crate::base::Char16; 0],
+    pub capsule_file_name_and_target: [crate::base::Char16; N],
 }
 
 //
@@ -425,12 +425,12 @@ pub const MEMORY_ATTRIBUTES_TABLE_VERSION: u32 = 0x00000001u32;
 
 #[repr(C)]
 #[derive(Clone, Copy, Debug)]
-pub struct MemoryAttributesTable {
+pub struct MemoryAttributesTable<const N: usize = 0> {
     pub version: u32,
     pub number_of_entries: u32,
     pub descriptor_size: u32,
     pub reserved: u32,
-    pub entry: [MemoryDescriptor; 0],
+    pub entry: [MemoryDescriptor; N],
 }
 
 //


### PR DESCRIPTION
This allows having a stack-allocated version of the type as well in cases the size of ZST is known at compile time. Since the default value of generic length has been set to 0, this should not be a breaking change.

Related to #41 

Signed-off-by: Ayush Singh <ayushsingh1325@gmail.com>