### PR TITLE
Add EFI_SHELL_PARAMETERS_PROTOCOL

### DIFF
--- a/src/protocols.rs
+++ b/src/protocols.rs
@@ -29,6 +29,7 @@ pub mod managed_network;
 pub mod rng;
 pub mod service_binding;
 pub mod shell;
+pub mod shell_parameters;
 pub mod simple_file_system;
 pub mod simple_network;
 pub mod simple_text_input;

--- a/src/protocols/shell_parameters.rs
+++ b/src/protocols/shell_parameters.rs
@@ -1,0 +1,23 @@
+//! Shell Parameters Protocol
+//!
+//! Defined in UEFI Shell Specification, Section 2.3
+
+use super::shell;
+
+pub const PROTOCOL_GUID: crate::base::Guid = crate::base::Guid::from_fields(
+    0x752f3136,
+    0x4e16,
+    0x4fdc,
+    0xa2,
+    0x2a,
+    &[0xe5, 0xf4, 0x68, 0x12, 0xf4, 0xca],
+);
+
+#[repr(C)]
+pub struct Protocol {
+    pub argv: *mut *mut crate::base::Char16,
+    pub argc: usize,
+    pub stdin: shell::FileHandle,
+    pub stdout: shell::FileHandle,
+    pub stderr: shell::FileHandle,
+}


### PR DESCRIPTION
Defined in UEFI Shell Specification, Section 2.3

Signed-off-by: Ayush Singh <ayushsingh1325@gmail.com>