### PR TITLE
base: unconditionally use stabilized "efiapi"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,8 @@ jobs:
       matrix:
         rust:
         - "nightly"
-        - "stable"
+#        - "stable"
+        - "1.68" # XXX: Workaround until github-runners update `stable`.
 
     steps:
     - name: "Fetch Sources"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ compiler_builtins = { version = '0.1.0', optional = true }
 core = { version = '1.0.0', optional = true, package = 'rustc-std-workspace-core' }
 
 [features]
-# Use the 'efiapi' calling convention designator (nightly-only).
+# No-op for backwards compatibility.
 efiapi = []
 # Maps to `native` for backwards compatibility.
 examples = ['native']

--- a/examples/uefi-cross-compile.rs
+++ b/examples/uefi-cross-compile.rs
@@ -23,7 +23,7 @@
 
 // compile-flags: --target x86_64-unknown-uefi
 
-#![feature(abi_efiapi, lang_items, no_core)]
+#![feature(lang_items, no_core)]
 #![no_core]
 #![no_main]
 

--- a/src/base.rs
+++ b/src/base.rs
@@ -127,59 +127,20 @@ compile_error!("The target endianness is not supported.");
 // eficall_abi!()
 //
 // This macro is the architecture-dependent implementation of eficall!(). See the documentation of
-// the eficall!() macro for a description.
+// the eficall!() macro for a description. Nowadays, this simply maps to `extern "efiapi"`, since
+// this has been stabilized with rust-1.68.
 
-#[cfg(feature = "efiapi")]
 #[macro_export]
 #[doc(hidden)]
 macro_rules! eficall_abi {
     (($($prefix:tt)*),($($suffix:tt)*)) => { $($prefix)* extern "efiapi" $($suffix)* };
 }
 
-#[cfg(all(target_arch = "arm", not(feature = "efiapi")))]
-#[macro_export]
-#[doc(hidden)]
-macro_rules! eficall_abi {
-    (($($prefix:tt)*),($($suffix:tt)*)) => { $($prefix)* extern "aapcs" $($suffix)* };
-}
-
-// XXX: Rust does not define aapcs64, yet. Once it does, we should switch to it, rather than
-//      referring to the system default.
-#[cfg(all(target_arch = "aarch64", not(feature = "efiapi")))]
-#[macro_export]
-#[doc(hidden)]
-macro_rules! eficall_abi {
-    (($($prefix:tt)*),($($suffix:tt)*)) => { $($prefix)* extern "C" $($suffix)* };
-}
-
-#[cfg(all(target_arch = "x86", not(feature = "efiapi")))]
-#[macro_export]
-#[doc(hidden)]
-macro_rules! eficall_abi {
-    (($($prefix:tt)*),($($suffix:tt)*)) => { $($prefix)* extern "cdecl" $($suffix)* };
-}
-
-#[cfg(all(target_arch = "x86_64", not(feature = "efiapi")))]
-#[macro_export]
-#[doc(hidden)]
-macro_rules! eficall_abi {
-    (($($prefix:tt)*),($($suffix:tt)*)) => { $($prefix)* extern "win64" $($suffix)* };
-}
-
-#[cfg(not(any(
-    feature = "efiapi",
-    target_arch = "arm",
-    target_arch = "aarch64",
-    target_arch = "x86",
-    target_arch = "x86_64"
-)))]
-#[macro_export]
-#[doc(hidden)]
-macro_rules! eficall_abi {
-    (($($prefix:tt)*),($($suffix:tt)*)) => { $($prefix)* extern "C" $($suffix)* };
-}
-
 /// Annotate function with UEFI calling convention
+///
+/// Since rust-1.68 you can use `extern "efiapi"` as calling-convention to achieve the same
+/// behavior as this macro. This macro is kept for backwards-compatibility only, but will nowadays
+/// map to `extern "efiapi"`.
 ///
 /// This macro takes a function-declaration as argument and produces the same function-declaration
 /// but annotated with the correct calling convention. Since the default `extern "C"` annotation
@@ -200,7 +161,6 @@ macro_rules! eficall_abi {
 /// inserted at the correct place:
 ///
 /// ```
-/// # #![cfg_attr(feature = "efiapi", feature(abi_efiapi))]
 /// use r_efi::{eficall, eficall_abi};
 ///
 /// eficall!{pub fn foobar() {
@@ -224,7 +184,6 @@ macro_rules! eficall_abi {
 /// is "C":
 ///
 /// ```
-/// # #![cfg_attr(feature = "efiapi", feature(abi_efiapi))]
 /// use r_efi::{eficall, eficall_abi};
 ///
 /// type FooBar1 = unsafe extern "C" fn(u8) -> (u8);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -123,11 +123,6 @@
 // basic unit-tests on the compilation host. For integration tests, we have separate compilation
 // units, so they will be unaffected by this.
 #![cfg_attr(not(test), no_std)]
-// The `efiapi` calling convention designator automatically picks the correct
-// EFI-compatible ABI for the target platform. It currently requires the
-// `abi_efiapi` unstable feature and is thus guarded by us behind the `efiapi`
-// crate-feature.
-#![cfg_attr(feature = "efiapi", feature(abi_efiapi))]
 
 // Import the different core modules. We separate them into different modules to make it easier to
 // work on them and describe what each part implements. This is different to the reference


### PR DESCRIPTION
With rust-1.68 the "efiapi" feature was stabilized. Use it unconditionally and turn the old feature into a no-op. As a next step we can replace all "efiapi!{}" calls with `extern "afiapi"`.

Rust-1.68 is scheduled to be released on March 9th, until then CI on the stable-channel will fail. This PR will have to wait until we bump the required rust-dependency to 1.68.