### PR TITLE
base: Add riscv64 to supported architectures

### DIFF
--- a/src/base.rs
+++ b/src/base.rs
@@ -117,6 +117,7 @@
 #[cfg(not(any(
     target_arch = "arm",
     target_arch = "aarch64",
+    target_arch = "riscv64",
     target_arch = "x86",
     target_arch = "x86_64"
 )))]


### PR DESCRIPTION
The EFI calling convention on this platform is the C calling
convention and is handled correctly by eficall!()

Signed-off-by: Rob Bradford <rbradford@rivosinc.com>
