### PR TITLE
protocols: Add hii_package_list

### DIFF
--- a/src/protocols.rs
+++ b/src/protocols.rs
@@ -21,6 +21,7 @@ pub mod graphics_output;
 pub mod hii_database;
 pub mod hii_font;
 pub mod hii_font_ex;
+pub mod hii_package_list;
 pub mod hii_string;
 pub mod ip4;
 pub mod ip6;

--- a/src/protocols/hii_package_list.rs
+++ b/src/protocols/hii_package_list.rs
@@ -1,0 +1,14 @@
+//! Human Interface Infrastructure (HII) Package List Protocol
+//!
+//! Installed onto an image handle during load if the image contains a custom PE/COFF
+//! resource with type 'HII'. The protocol's interface pointer points to the HII package
+//! list which is contained in the resource's data.
+
+pub const PROTOCOL_GUID: crate::base::Guid = crate::base::Guid::from_fields(
+    0x6a1ee763,
+    0xd47a,
+    0x43b4,
+    0xaa,
+    0xbe,
+    &[0xef, 0x1d, 0xe2, 0xab, 0x56, 0xfc],
+);


### PR DESCRIPTION
Adds the EFI_HII_PACKAGE_LIST_PROTOCOL as described in the UEFI Specification, Release 2.10, Section 7.4.1 - EFI_BOOT_SERVICES.LoadImage() - Related Definitions.