### PR TITLE
Add Driver Override Protocol definitions. 

### DIFF
--- a/src/protocols.rs
+++ b/src/protocols.rs
@@ -30,6 +30,7 @@ pub mod loaded_image;
 pub mod loaded_image_device_path;
 pub mod managed_network;
 pub mod mp_services;
+pub mod platform_driver_override;
 pub mod rng;
 pub mod service_binding;
 pub mod shell;

--- a/src/protocols.rs
+++ b/src/protocols.rs
@@ -6,6 +6,7 @@
 
 pub mod absolute_pointer;
 pub mod block_io;
+pub mod bus_specific_driver_override;
 pub mod debug_support;
 pub mod debugport;
 pub mod decompress;

--- a/src/protocols.rs
+++ b/src/protocols.rs
@@ -18,6 +18,7 @@ pub mod disk_io;
 pub mod disk_io2;
 pub mod driver_binding;
 pub mod driver_diagnostics2;
+pub mod driver_family_override;
 pub mod file;
 pub mod graphics_output;
 pub mod hii_database;

--- a/src/protocols/bus_specific_driver_override.rs
+++ b/src/protocols/bus_specific_driver_override.rs
@@ -1,0 +1,31 @@
+//! Bus Specific Driver Override Protocol
+//!
+//! This protocol matches one or more drivers to a controller. This protocol is
+//! produced by a bus driver, and it is installed on the child handles of buses
+//! that require a bus specific algorithm for matching drivers to controllers.
+//! This protocol is used by the EFI_BOOT_SERVICES.ConnectController() boot
+//! service to select the best driver for a controller. All of the drivers
+//! returned by this protocol have a higher precedence than drivers found in
+//! the general EFI Driver Binding search algorithm, but a lower precedence
+//! than those drivers returned by the EFI Platform Driver Override Protocol.
+//! If more than one driver image handle is returned by this protocol, then the
+//! drivers image handles are returned in order from highest precedence to
+//! lowest precedence.
+pub const PROTOCOL_GUID: crate::base::Guid = crate::base::Guid::from_fields(
+    0x3bc1b285,
+    0x8a15,
+    0x4a82,
+    0xaa,
+    0xbf,
+    &[0x4d, 0x7d, 0x13, 0xfb, 0x32, 0x65],
+);
+
+pub type ProtocolGetDriver = eficall! {fn(
+    *mut Protocol,
+    *mut crate::base::Handle,
+) -> crate::base::Status};
+
+#[repr(C)]
+pub struct Protocol {
+    pub get_driver: ProtocolGetDriver,
+}

--- a/src/protocols/driver_family_override.rs
+++ b/src/protocols/driver_family_override.rs
@@ -1,0 +1,22 @@
+//! Driver Family Override Protocol
+//!
+//! When installed, the Driver Family Override Protocol informs the UEFI Boot
+//! Service ConnectController() that this driver is higher priority than the
+//! list of drivers returned by the Bus Specific Driver Override Protocol.
+pub const PROTOCOL_GUID: crate::base::Guid = crate::base::Guid::from_fields(
+    0xb1ee129e,
+    0xda36,
+    0x4181,
+    0x91,
+    0xf8,
+    &[0x04, 0xa4, 0x92, 0x37, 0x66, 0xa7],
+);
+
+pub type ProtocolGetVersion = eficall! {fn(
+    *mut Protocol,
+) -> u32};
+
+#[repr(C)]
+pub struct Protocol {
+    pub get_version: ProtocolGetVersion,
+}

--- a/src/protocols/platform_driver_override.rs
+++ b/src/protocols/platform_driver_override.rs
@@ -1,0 +1,45 @@
+//! Platform Driver Override Protocol
+//!
+//! This protocol matches one or more drivers to a controller. A platform driver
+//! produces this protocol, and it is installed on a separate handle. This
+//! protocol is used by the EFI_BOOT_SERVICES.ConnectController() boot service
+//! to select the best driver for a controller. All of the drivers returned by
+//! this protocol have a higher precedence than drivers found from an EFI Bus
+//! Specific Driver Override Protocol or drivers found from the general UEFI
+//! driver binding search algorithm. If more than one driver is returned by this
+//! protocol, then the drivers are returned in order from highest precedence to
+//! lowest precedence.
+pub const PROTOCOL_GUID: crate::base::Guid = crate::base::Guid::from_fields(
+    0x6b30c738,
+    0xa391,
+    0x11d4,
+    0x9a,
+    0x3b,
+    &[0x00, 0x90, 0x27, 0x3f, 0xc1, 0x4d],
+);
+
+pub type ProtocolGetDriver = eficall! {fn(
+    *mut Protocol,
+    crate::base::Handle,
+    *mut crate::base::Handle,
+) -> crate::base::Status};
+
+pub type ProtocolGetDriverPath = eficall! {fn(
+    *mut Protocol,
+    crate::base::Handle,
+    *mut *mut crate::protocols::device_path::Protocol
+) -> crate::base::Status};
+
+pub type ProtocolDriverLoaded = eficall! {fn(
+    *mut Protocol,
+    crate::base::Handle,
+    *mut crate::protocols::device_path::Protocol,
+    crate::base::Handle,
+) -> crate::base::Status};
+
+#[repr(C)]
+pub struct Protocol {
+    pub get_driver: ProtocolGetDriver,
+    pub get_driver_path: ProtocolGetDriverPath,
+    pub driver_loaded: ProtocolDriverLoaded,
+}


### PR DESCRIPTION
This PR adds the 3 driver override protocol definitions specified UEFI 2.10 spec sections 11.2, 11.3, and 11.9.