### PR TITLE
Add Media Device Path subtypes

### DIFF
--- a/src/protocols/device_path.rs
+++ b/src/protocols/device_path.rs
@@ -64,3 +64,19 @@ pub struct HardDriveMedia {
     pub partition_format: u8,
     pub signature_type: u8,
 }
+
+pub struct Media {
+    pub header: Protocol,
+}
+
+impl Media {
+    pub const SUBTYPE_HARDDRIVE: u8 = 0x01;
+    pub const SUBTYPE_CDROM: u8 = 0x02;
+    pub const SUBTYPE_VENDOR: u8 = 0x03;
+    pub const SUBTYPE_FILE_PATH: u8 = 0x04;
+    pub const SUBTYPE_MEDIA_PROTOCOL: u8 = 0x05;
+    pub const SUBTYPE_PIWG_FIRMWARE_FILE: u8 = 0x06;
+    pub const SUBTYPE_PIWG_FIRMWARE_VOLUME: u8 = 0x07;
+    pub const SUBTYPE_RELATIVE_OFFSET_RANGE: u8 = 0x08;
+    pub const SUBTYPE_RAM_DISK: u8 = 0x09;
+}


### PR DESCRIPTION
Add sub-type definitions for Media DevicePath type per section 10.3.5 of UEFI Spec 2.10.