### PR TITLE
base: more traits for basic types

### DIFF
--- a/src/base.rs
+++ b/src/base.rs
@@ -296,7 +296,8 @@ pub type Char16 = u16;
 /// on the context, different state is stored in it. Note that it is always binary compatible to a
 /// usize!
 #[repr(C)]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Default)]
+#[derive(Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct Status(usize);
 
 /// Object Handles

--- a/src/base.rs
+++ b/src/base.rs
@@ -387,7 +387,8 @@ pub type ImageEntryPoint = eficall! {fn(Handle, *mut crate::system::SystemTable)
 /// The individual fields are encoded as little-endian. Accessors are provided for the Guid
 /// structure allowing access to these fields in native endian byte order.
 #[repr(C, align(4))]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug)]
+#[derive(Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct Guid {
     time_low: [u8; 4],
     time_mid: [u8; 2],

--- a/src/base.rs
+++ b/src/base.rs
@@ -273,7 +273,8 @@ macro_rules! eficall {
 /// However, on the rust side you will never see the integer value. It instead behaves truly as a
 /// boolean. If you need access to the integer value, you have to transmute it back to `u8`.
 #[repr(C)]
-#[derive(Clone, Copy, Debug, Eq)]
+#[derive(Clone, Copy, Debug)]
+// Manual impls for: Default, Eq, Hash, Ord, PartialEq, PartialOrd
 pub struct Boolean(u8);
 
 /// Single-byte Character Type
@@ -479,6 +480,15 @@ impl Default for Boolean {
     }
 }
 
+impl From<Boolean> for u8 {
+    fn from(v: Boolean) -> Self {
+        match v.0 {
+            0 => 0,
+            _ => 1,
+        }
+    }
+}
+
 impl From<Boolean> for bool {
     fn from(v: Boolean) -> Self {
         match v.0 {
@@ -488,15 +498,41 @@ impl From<Boolean> for bool {
     }
 }
 
+impl Eq for Boolean {}
+
+impl core::hash::Hash for Boolean {
+    fn hash<H: core::hash::Hasher>(&self, state: &mut H) {
+        bool::from(*self).hash(state)
+    }
+}
+
+impl Ord for Boolean {
+    fn cmp(&self, other: &Boolean) -> core::cmp::Ordering {
+        bool::from(*self).cmp(&(*other).into())
+    }
+}
+
 impl PartialEq for Boolean {
     fn eq(&self, other: &Boolean) -> bool {
-        <bool as From<Boolean>>::from(*self) == (*other).into()
+        bool::from(*self).eq(&(*other).into())
     }
 }
 
 impl PartialEq<bool> for Boolean {
     fn eq(&self, other: &bool) -> bool {
-        *other == (*self).into()
+        bool::from(*self).eq(other)
+    }
+}
+
+impl PartialOrd for Boolean {
+    fn partial_cmp(&self, other: &Boolean) -> Option<core::cmp::Ordering> {
+        bool::from(*self).partial_cmp(&(*other).into())
+    }
+}
+
+impl PartialOrd<bool> for Boolean {
+    fn partial_cmp(&self, other: &bool) -> Option<core::cmp::Ordering> {
+        bool::from(*self).partial_cmp(other)
     }
 }
 
@@ -725,6 +761,13 @@ mod tests {
     use super::*;
     use std::mem::{align_of, size_of};
 
+    // Helper to compute a hash of an object.
+    fn hash<T: core::hash::Hash>(v: &T) -> u64 {
+        let mut h = std::hash::DefaultHasher::new();
+        v.hash(&mut h);
+        core::hash::Hasher::finish(&h)
+    }
+
     // Verify Type Size and Alignemnt
     //
     // Since UEFI defines explicitly the ABI of their types, we can verify that our implementation
@@ -873,6 +916,17 @@ mod tests {
                     assert_ne!(v1, true);
                     assert_ne!(v2, Boolean::TRUE);
                     assert_ne!(v2, true);
+
+                    assert!(v1 < Boolean::TRUE);
+                    assert!(v1 < true);
+                    assert!(v1 >= Boolean::FALSE);
+                    assert!(v1 >= false);
+                    assert!(v1 <= Boolean::FALSE);
+                    assert!(v1 <= false);
+                    assert_eq!(v1.cmp(&true.into()), core::cmp::Ordering::Less);
+                    assert_eq!(v1.cmp(&false.into()), core::cmp::Ordering::Equal);
+
+                    assert_eq!(hash(&v1), hash(&false));
                 }
                 _ => {
                     assert_eq!(v1, Boolean::TRUE);
@@ -884,6 +938,17 @@ mod tests {
                     assert_ne!(v1, false);
                     assert_ne!(v2, Boolean::FALSE);
                     assert_ne!(v2, false);
+
+                    assert!(v1 <= Boolean::TRUE);
+                    assert!(v1 <= true);
+                    assert!(v1 >= Boolean::TRUE);
+                    assert!(v1 >= true);
+                    assert!(v1 > Boolean::FALSE);
+                    assert!(v1 > false);
+                    assert_eq!(v1.cmp(&true.into()), core::cmp::Ordering::Equal);
+                    assert_eq!(v1.cmp(&false.into()), core::cmp::Ordering::Greater);
+
+                    assert_eq!(hash(&v1), hash(&true));
                 }
             }
         }

--- a/src/base.rs
+++ b/src/base.rs
@@ -410,6 +410,7 @@ pub struct Guid {
 /// an Ethernet address.
 #[repr(C)]
 #[derive(Clone, Copy, Debug)]
+#[derive(Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct MacAddress {
     pub addr: [u8; 32],
 }
@@ -420,7 +421,8 @@ pub struct MacAddress {
 /// order (i.e., big endian). Note that no special alignment restrictions are
 /// defined by the standard specification.
 #[repr(C)]
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Default)]
+#[derive(Clone, Copy, Debug, Default)]
+#[derive(Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct Ipv4Address {
     pub addr: [u8; 4],
 }
@@ -431,7 +433,8 @@ pub struct Ipv4Address {
 /// (i.e., big endian). Similar to the IPv4 address, no special alignment
 /// restrictions are defined by the standard specification.
 #[repr(C)]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug)]
+#[derive(Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct Ipv6Address {
     pub addr: [u8; 16],
 }


### PR DESCRIPTION
A collection of `derive` and `impl` additions to the basic UEFI types. The idea is to allow storing them in collections of the standard library, without requiring any wrapper types.

Cc: @joschock #80