### PR TITLE
Make unload function of loaded image protocol an Option

### DIFF
--- a/src/protocols/loaded_image.rs
+++ b/src/protocols/loaded_image.rs
@@ -35,5 +35,5 @@ pub struct Protocol {
     pub image_size: u64,
     pub image_code_type: crate::system::MemoryType,
     pub image_data_type: crate::system::MemoryType,
-    pub unload: ProtocolUnload,
+    pub unload: Option<ProtocolUnload>,
 }


### PR DESCRIPTION
This change makes a the "unload" function pointer of the loaded image protocol an `Option` in line with the Transpose Guidelines in lib.rs. This pointer is often NULL, which makes it UB to interact with in Rust if it is not an option.
