### PR TITLE
MemoryAttributesTable: Remove Const Generic Parameter and Copy/Clone

### DIFF
--- a/src/system.rs
+++ b/src/system.rs
@@ -496,13 +496,13 @@ pub const MEMORY_ATTRIBUTES_TABLE_GUID: crate::base::Guid = crate::base::Guid::f
 pub const MEMORY_ATTRIBUTES_TABLE_VERSION: u32 = 0x00000001u32;
 
 #[repr(C)]
-#[derive(Clone, Copy, Debug)]
-pub struct MemoryAttributesTable<const N: usize = 0> {
+#[derive(Debug)]
+pub struct MemoryAttributesTable {
     pub version: u32,
     pub number_of_entries: u32,
     pub descriptor_size: u32,
     pub reserved: u32,
-    pub entry: [MemoryDescriptor; N],
+    pub entry: [MemoryDescriptor; 0],
 }
 
 pub const CONFORMANCE_PROFILES_TABLE_GUID: crate::base::Guid = crate::base::Guid::from_fields(


### PR DESCRIPTION
The MemoryAttributesTable definition in r-efi currently has a const generic parameter for the size of the `entry` array. However, this size can never be known at compile time: the MAT is generated many times during boot with varying sizes of entries, depending on how many RUNTIME_SERVICES_CODE and RUNTIME_SERVICES_DATA allocated sections in the memory map there are. Therefore, when writing code to produce the MAT, the only compile time value that can be used is 0 and the structure must be overallocated.

This commit updates the structure to remove the const generic and use 0 for the entry array size, as that is the only value that can be used. It also removes Clone and Copy from the derived traits, because it does not make sense to clone or copy a structure that is overallocated with a 0 length array: you would miss all the actual entries in the structure and if you just wanted to copy the header that is trivial to do.

Note that a dynamically sized type cannot be used here either: Rust can only store a pointer to that structure, at compile time you have to coerce the unsized element into a sized element, which has the same issue as using a const generic here: we don't know the size at compile time.