### PR TITLE
protocols: Add Memory Attributes Protocol

### DIFF
--- a/src/protocols.rs
+++ b/src/protocols.rs
@@ -33,6 +33,7 @@ pub mod load_file2;
 pub mod loaded_image;
 pub mod loaded_image_device_path;
 pub mod managed_network;
+pub mod memory_attribute;
 pub mod mp_services;
 pub mod pci_io;
 pub mod platform_driver_override;

--- a/src/protocols/memory_attribute.rs
+++ b/src/protocols/memory_attribute.rs
@@ -1,0 +1,40 @@
+//! Memory Attribute Protocol
+//!
+//! Provides an interface to abstract setting or getting of memory attributes in the UEFI environment.
+
+pub const PROTOCOL_GUID: crate::base::Guid = crate::base::Guid::from_fields(
+    0xf4560cf6,
+    0x40ec,
+    0x4b4a,
+    0xa1,
+    0x92,
+    &[0xbf, 0x1d, 0x57, 0xd0, 0xb1, 0x89],
+);
+
+pub type GetMemoryAttributes = eficall! {fn(
+    *mut Protocol,
+    crate::base::PhysicalAddress,
+    u64,
+    *mut u64,
+) -> crate::base::Status};
+
+pub type SetMemoryAttributes = eficall! {fn(
+    *mut Protocol,
+    crate::base::PhysicalAddress,
+    u64,
+    u64,
+) -> crate::base::Status};
+
+pub type ClearMemoryAttributes = eficall! {fn(
+    *mut Protocol,
+    crate::base::PhysicalAddress,
+    u64,
+    u64,
+) -> crate::base::Status};
+
+#[repr(C)]
+pub struct Protocol {
+    pub get_memory_attributes: GetMemoryAttributes,
+    pub set_memory_attributes: SetMemoryAttributes,
+    pub clear_memory_attributes: ClearMemoryAttributes,
+}


### PR DESCRIPTION
This PR adds the Memory Attributes Protocol as defined in UEFI Spec 2.10A section 37.7.1: https://uefi.org/specs/UEFI/2.10/37_Secure_Technologies.html#efi-memory-attribute-protocol.