### PR TITLE
Use variadic function signatures

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ keywords = [
 license = "MIT OR Apache-2.0 OR LGPL-2.1-or-later"
 readme = "README.md"
 repository = "https://github.com/r-efi/r-efi"
-rust-version = "1.68"
+rust-version = "1.85"
 
 [dependencies]
 # Required setup to build as part of rustc.

--- a/src/base.rs
+++ b/src/base.rs
@@ -230,11 +230,7 @@ macro_rules! eficall_abi {
 ///
 /// # Variadics
 ///
-/// For some reason, the rust compiler allows variadics only in combination with the `"C"` calling
-/// convention, even if the selected calling-convention matches what `"C"` would select on the
-/// target platform. Hence, you will very likely be unable to use variadics with this macro.
-/// Luckily, all of the UEFI functions that use variadics are wrappers around more low-level
-/// accessors, so they are not necessarily required.
+/// Supported since rust-1.84.0
 #[macro_export]
 macro_rules! eficall {
     // Muncher

--- a/src/system.rs
+++ b/src/system.rs
@@ -991,16 +991,12 @@ pub type BootLocateProtocol = eficall! {fn(
 
 pub type BootInstallMultipleProtocolInterfaces = eficall! {fn(
     *mut crate::base::Handle,
-    // XXX: Actual definition is variadic. See eficall!{} for details.
-    *mut core::ffi::c_void,
-    *mut core::ffi::c_void,
+    ...
 ) -> crate::base::Status};
 
 pub type BootUninstallMultipleProtocolInterfaces = eficall! {fn(
     crate::base::Handle,
-    // XXX: Actual definition is variadic. See eficall!{} for details.
-    *mut core::ffi::c_void,
-    *mut core::ffi::c_void,
+    ...
 ) -> crate::base::Status};
 
 pub type BootCalculateCrc32 = eficall! {fn(


### PR DESCRIPTION
`extended_varargs_abi_support` has been stablized which enables variadic functions in `efiapi`: https://github.com/rust-lang/rust/pull/116161

Keeping this as draft till a new stable version of Rust is released. Feel free to comment if any other variadic functions are present.