### PR TITLE
Fix signatures of most EFI functions to be unsafe

### DIFF
--- a/src/base.rs
+++ b/src/base.rs
@@ -353,7 +353,7 @@ pub type VirtualAddress = u64;
 /// invocation, if invoked as an UEFI driver.
 /// In most cases it is perfectly fine to cast the pointer to a real rust reference. However, this
 /// should be an explicit decision by the caller.
-pub type ImageEntryPoint = eficall! {fn(Handle, *mut crate::system::SystemTable) -> Status};
+pub type ImageEntryPoint = eficall! {unsafe fn(Handle, *mut crate::system::SystemTable) -> Status};
 
 /// Globally Unique Identifiers
 ///

--- a/src/protocols/absolute_pointer.rs
+++ b/src/protocols/absolute_pointer.rs
@@ -50,12 +50,12 @@ pub struct State {
     pub active_buttons: u32,
 }
 
-pub type Reset = eficall! {fn(
+pub type Reset = eficall! {unsafe fn(
     this: *mut Protocol,
     extended_verification: bool,
 ) -> crate::base::Status};
 
-pub type GetState = eficall! {fn(
+pub type GetState = eficall! {unsafe fn(
     this: *mut Protocol,
     state: *mut State,
 ) -> crate::base::Status};

--- a/src/protocols/block_io.rs
+++ b/src/protocols/block_io.rs
@@ -34,12 +34,12 @@ pub struct Media {
     pub optimal_transfer_length_granularity: u32,
 }
 
-pub type ProtocolReset = eficall! {fn(
+pub type ProtocolReset = eficall! {unsafe fn(
     *mut Protocol,
     crate::base::Boolean,
 ) -> crate::base::Status};
 
-pub type ProtocolReadBlocks = eficall! {fn(
+pub type ProtocolReadBlocks = eficall! {unsafe fn(
     *mut Protocol,
     u32,
     crate::base::Lba,
@@ -47,7 +47,7 @@ pub type ProtocolReadBlocks = eficall! {fn(
     *mut core::ffi::c_void,
 ) -> crate::base::Status};
 
-pub type ProtocolWriteBlocks = eficall! {fn(
+pub type ProtocolWriteBlocks = eficall! {unsafe fn(
     *mut Protocol,
     u32,
     crate::base::Lba,
@@ -55,7 +55,7 @@ pub type ProtocolWriteBlocks = eficall! {fn(
     *mut core::ffi::c_void,
 ) -> crate::base::Status};
 
-pub type ProtocolFlushBlocks = eficall! {fn(
+pub type ProtocolFlushBlocks = eficall! {unsafe fn(
     *mut Protocol,
 ) -> crate::base::Status};
 

--- a/src/protocols/bus_specific_driver_override.rs
+++ b/src/protocols/bus_specific_driver_override.rs
@@ -21,7 +21,7 @@ pub const PROTOCOL_GUID: crate::base::Guid = crate::base::Guid::from_fields(
     &[0x4d, 0x7d, 0x13, 0xfb, 0x32, 0x65],
 );
 
-pub type ProtocolGetDriver = eficall! {fn(
+pub type ProtocolGetDriver = eficall! {unsafe fn(
     *mut Protocol,
     *mut crate::base::Handle,
 ) -> crate::base::Status};

--- a/src/protocols/debug_support.rs
+++ b/src/protocols/debug_support.rs
@@ -796,29 +796,29 @@ pub const EXCEPT_RISCV_MACHINE_TIMER_INT: ExceptionType = 7;
 pub const EXCEPT_RISCV_SUPERVISOR_EXTERNAL_INT: ExceptionType = 9;
 pub const EXCEPT_RISCV_MACHINE_EXTERNAL_INT: ExceptionType = 11;
 
-pub type GetMaximumProcessorIndex = eficall! {fn(
+pub type GetMaximumProcessorIndex = eficall! {unsafe fn(
     *mut Protocol,
     *mut usize,
 ) -> crate::base::Status};
 
-pub type PeriodicCallback = eficall! {fn(SystemContext)};
+pub type PeriodicCallback = eficall! {unsafe fn(SystemContext)};
 
-pub type RegisterPeriodicCallback = eficall! {fn(
+pub type RegisterPeriodicCallback = eficall! {unsafe fn(
     *mut Protocol,
     usize,
     Option<PeriodicCallback>,
 ) -> crate::base::Status};
 
-pub type ExceptionCallback = eficall! {fn(ExceptionType, SystemContext)};
+pub type ExceptionCallback = eficall! {unsafe fn(ExceptionType, SystemContext)};
 
-pub type RegisterExceptionCallback = eficall! {fn(
+pub type RegisterExceptionCallback = eficall! {unsafe fn(
     *mut Protocol,
     usize,
     Option<ExceptionCallback>,
     ExceptionType,
 ) -> crate::base::Status};
 
-pub type InvalidateInstructionCache = eficall! {fn(
+pub type InvalidateInstructionCache = eficall! {unsafe fn(
     *mut Protocol,
     usize,
     *mut core::ffi::c_void,

--- a/src/protocols/debugport.rs
+++ b/src/protocols/debugport.rs
@@ -11,25 +11,25 @@ pub const PROTOCOL_GUID: crate::base::Guid = crate::base::Guid::from_fields(
     &[0x26, 0x47, 0xba, 0x96, 0x60, 0xd0],
 );
 
-pub type Reset = eficall! {fn(
+pub type Reset = eficall! {unsafe fn(
     *mut Protocol,
 ) -> *mut crate::base::Status};
 
-pub type Write = eficall! {fn(
-    *mut Protocol,
-    u32,
-    *mut usize,
-    *mut core::ffi::c_void
-) -> *mut crate::base::Status};
-
-pub type Read = eficall! {fn(
+pub type Write = eficall! {unsafe fn(
     *mut Protocol,
     u32,
     *mut usize,
     *mut core::ffi::c_void
 ) -> *mut crate::base::Status};
 
-pub type Poll = eficall! {fn(
+pub type Read = eficall! {unsafe fn(
+    *mut Protocol,
+    u32,
+    *mut usize,
+    *mut core::ffi::c_void
+) -> *mut crate::base::Status};
+
+pub type Poll = eficall! {unsafe fn(
     *mut Protocol,
 ) -> *mut crate::base::Status};
 

--- a/src/protocols/decompress.rs
+++ b/src/protocols/decompress.rs
@@ -12,7 +12,7 @@ pub const PROTOCOL_GUID: crate::base::Guid = crate::base::Guid::from_fields(
     &[0x00, 0x90, 0x27, 0x3f, 0xc1, 0x4d],
 );
 
-pub type ProtocolGetInfo = eficall! {fn(
+pub type ProtocolGetInfo = eficall! {unsafe fn(
     *mut Protocol,
     *mut core::ffi::c_void,
     u32,
@@ -20,7 +20,7 @@ pub type ProtocolGetInfo = eficall! {fn(
     *mut u32,
 ) -> crate::base::Status};
 
-pub type ProtocolDecompress = eficall! {fn(
+pub type ProtocolDecompress = eficall! {unsafe fn(
     *mut Protocol,
     *mut core::ffi::c_void,
     u32,

--- a/src/protocols/device_path_from_text.rs
+++ b/src/protocols/device_path_from_text.rs
@@ -11,11 +11,11 @@ pub const PROTOCOL_GUID: crate::base::Guid = crate::base::Guid::from_fields(
     &[0x35, 0xdf, 0x33, 0x43, 0xf5, 0x1e],
 );
 
-pub type DevicePathFromTextNode = eficall! {fn(
+pub type DevicePathFromTextNode = eficall! {unsafe fn(
     *const crate::base::Char16,
 ) -> *mut crate::protocols::device_path::Protocol};
 
-pub type DevicePathFromTextPath = eficall! {fn(
+pub type DevicePathFromTextPath = eficall! {unsafe fn(
     *const crate::base::Char16,
 ) -> *mut crate::protocols::device_path::Protocol};
 

--- a/src/protocols/device_path_to_text.rs
+++ b/src/protocols/device_path_to_text.rs
@@ -11,13 +11,13 @@ pub const PROTOCOL_GUID: crate::base::Guid = crate::base::Guid::from_fields(
     &[0x55, 0x1a, 0x4e, 0x4a, 0x7f, 0x1c],
 );
 
-pub type DevicePathToTextNode = eficall! {fn(
+pub type DevicePathToTextNode = eficall! {unsafe fn(
     *mut crate::protocols::device_path::Protocol,
     crate::base::Boolean,
     crate::base::Boolean,
 ) -> *mut crate::base::Char16};
 
-pub type DevicePathToTextPath = eficall! {fn(
+pub type DevicePathToTextPath = eficall! {unsafe fn(
     *mut crate::protocols::device_path::Protocol,
     crate::base::Boolean,
     crate::base::Boolean,

--- a/src/protocols/device_path_utilities.rs
+++ b/src/protocols/device_path_utilities.rs
@@ -12,35 +12,35 @@ pub const PROTOCOL_GUID: crate::base::Guid = crate::base::Guid::from_fields(
     &[0xed, 0xb8, 0x2f, 0xb7, 0x72, 0xa4],
 );
 
-pub type ProtocolGetDevicePathSize = eficall! {fn(
+pub type ProtocolGetDevicePathSize = eficall! {unsafe fn(
     *const crate::protocols::device_path::Protocol,
 ) -> usize};
 
-pub type ProtocolDuplicateDevicePath = eficall! {fn(
+pub type ProtocolDuplicateDevicePath = eficall! {unsafe fn(
     *const crate::protocols::device_path::Protocol,
 ) -> *mut crate::protocols::device_path::Protocol};
 
-pub type ProtocolAppendDevicePath = eficall! {fn(
-    *const crate::protocols::device_path::Protocol,
-    *const crate::protocols::device_path::Protocol,
-) -> *mut crate::protocols::device_path::Protocol};
-
-pub type ProtocolAppendDeviceNode = eficall! {fn(
+pub type ProtocolAppendDevicePath = eficall! {unsafe fn(
     *const crate::protocols::device_path::Protocol,
     *const crate::protocols::device_path::Protocol,
 ) -> *mut crate::protocols::device_path::Protocol};
 
-pub type ProtocolAppendDevicePathInstance = eficall! {fn(
+pub type ProtocolAppendDeviceNode = eficall! {unsafe fn(
     *const crate::protocols::device_path::Protocol,
     *const crate::protocols::device_path::Protocol,
 ) -> *mut crate::protocols::device_path::Protocol};
 
-pub type ProtocolGetNextDevicePathInstance = eficall! {fn(
+pub type ProtocolAppendDevicePathInstance = eficall! {unsafe fn(
+    *const crate::protocols::device_path::Protocol,
+    *const crate::protocols::device_path::Protocol,
+) -> *mut crate::protocols::device_path::Protocol};
+
+pub type ProtocolGetNextDevicePathInstance = eficall! {unsafe fn(
     *mut *mut crate::protocols::device_path::Protocol,
     *mut usize,
 ) -> *mut crate::protocols::device_path::Protocol};
 
-pub type ProtocolIsDevicePathMultiInstance = eficall! {fn(
+pub type ProtocolIsDevicePathMultiInstance = eficall! {unsafe fn(
     *const crate::protocols::device_path::Protocol,
 ) -> crate::base::Boolean};
 

--- a/src/protocols/disk_io.rs
+++ b/src/protocols/disk_io.rs
@@ -16,7 +16,7 @@ pub const PROTOCOL_GUID: crate::base::Guid = crate::base::Guid::from_fields(
 
 pub const REVISION: u64 = 0x0000000000010000u64;
 
-pub type ProtocolReadDisk = eficall! {fn(
+pub type ProtocolReadDisk = eficall! {unsafe fn(
     *mut Protocol,
     u32,
     u64,
@@ -24,7 +24,7 @@ pub type ProtocolReadDisk = eficall! {fn(
     *mut core::ffi::c_void,
 ) -> crate::base::Status};
 
-pub type ProtocolWriteDisk = eficall! {fn(
+pub type ProtocolWriteDisk = eficall! {unsafe fn(
     *mut Protocol,
     u32,
     u64,

--- a/src/protocols/disk_io2.rs
+++ b/src/protocols/disk_io2.rs
@@ -21,20 +21,11 @@ pub struct Token {
     transaction_status: crate::base::Status,
 }
 
-pub type ProtocolCancel = eficall! {fn(
+pub type ProtocolCancel = eficall! {unsafe fn(
     *mut Protocol,
 ) -> crate::base::Status};
 
-pub type ProtocolReadDiskEx = eficall! {fn(
-    *mut Protocol,
-    u32,
-    u64,
-    *mut Token,
-    usize,
-    *mut core::ffi::c_void,
-) -> crate::base::Status};
-
-pub type ProtocolWriteDiskEx = eficall! {fn(
+pub type ProtocolReadDiskEx = eficall! {unsafe fn(
     *mut Protocol,
     u32,
     u64,
@@ -43,7 +34,16 @@ pub type ProtocolWriteDiskEx = eficall! {fn(
     *mut core::ffi::c_void,
 ) -> crate::base::Status};
 
-pub type ProtocolFlushDiskEx = eficall! {fn(
+pub type ProtocolWriteDiskEx = eficall! {unsafe fn(
+    *mut Protocol,
+    u32,
+    u64,
+    *mut Token,
+    usize,
+    *mut core::ffi::c_void,
+) -> crate::base::Status};
+
+pub type ProtocolFlushDiskEx = eficall! {unsafe fn(
     *mut Protocol,
     *mut Token,
 ) -> crate::base::Status};

--- a/src/protocols/driver_binding.rs
+++ b/src/protocols/driver_binding.rs
@@ -12,19 +12,19 @@ pub const PROTOCOL_GUID: crate::base::Guid = crate::base::Guid::from_fields(
     &[0x0c, 0x09, 0x26, 0x1e, 0x9f, 0x71],
 );
 
-pub type ProtocolSupported = eficall! {fn(
+pub type ProtocolSupported = eficall! {unsafe fn(
     *mut Protocol,
     crate::base::Handle,
     *mut crate::protocols::device_path::Protocol,
 ) -> crate::base::Status};
 
-pub type ProtocolStart = eficall! {fn(
+pub type ProtocolStart = eficall! {unsafe fn(
     *mut Protocol,
     crate::base::Handle,
     *mut crate::protocols::device_path::Protocol,
 ) -> crate::base::Status};
 
-pub type ProtocolStop = eficall! {fn(
+pub type ProtocolStop = eficall! {unsafe fn(
     *mut Protocol,
     crate::base::Handle,
     usize,

--- a/src/protocols/driver_diagnostics2.rs
+++ b/src/protocols/driver_diagnostics2.rs
@@ -20,7 +20,7 @@ pub const TYPE_MANUFACTURING: Type = 2;
 pub const TYPE_CANCEL: Type = 3;
 pub const TYPE_MAXIMUM: Type = 4;
 
-pub type RunDiagnostics = eficall! {fn(
+pub type RunDiagnostics = eficall! {unsafe fn(
     *mut Protocol,
     crate::base::Handle,
     crate::base::Handle,

--- a/src/protocols/driver_family_override.rs
+++ b/src/protocols/driver_family_override.rs
@@ -13,7 +13,7 @@ pub const PROTOCOL_GUID: crate::base::Guid = crate::base::Guid::from_fields(
     &[0x04, 0xa4, 0x92, 0x37, 0x66, 0xa7],
 );
 
-pub type ProtocolGetVersion = eficall! {fn(
+pub type ProtocolGetVersion = eficall! {unsafe fn(
     *mut Protocol,
 ) -> u32};
 

--- a/src/protocols/file.rs
+++ b/src/protocols/file.rs
@@ -83,7 +83,7 @@ pub struct SystemVolumeLabel<const N: usize = 0> {
     pub volume_label: [crate::base::Char16; N],
 }
 
-pub type ProtocolOpen = eficall! {fn(
+pub type ProtocolOpen = eficall! {unsafe fn(
     *mut Protocol,
     *mut *mut Protocol,
     *mut crate::base::Char16,
@@ -91,55 +91,55 @@ pub type ProtocolOpen = eficall! {fn(
     u64,
 ) -> crate::base::Status};
 
-pub type ProtocolClose = eficall! {fn(
+pub type ProtocolClose = eficall! {unsafe fn(
     *mut Protocol,
 ) -> crate::base::Status};
 
-pub type ProtocolDelete = eficall! {fn(
+pub type ProtocolDelete = eficall! {unsafe fn(
     *mut Protocol,
 ) -> crate::base::Status};
 
-pub type ProtocolRead = eficall! {fn(
-    *mut Protocol,
-    *mut usize,
-    *mut core::ffi::c_void,
-) -> crate::base::Status};
-
-pub type ProtocolWrite = eficall! {fn(
+pub type ProtocolRead = eficall! {unsafe fn(
     *mut Protocol,
     *mut usize,
     *mut core::ffi::c_void,
 ) -> crate::base::Status};
 
-pub type ProtocolGetPosition = eficall! {fn(
+pub type ProtocolWrite = eficall! {unsafe fn(
+    *mut Protocol,
+    *mut usize,
+    *mut core::ffi::c_void,
+) -> crate::base::Status};
+
+pub type ProtocolGetPosition = eficall! {unsafe fn(
     *mut Protocol,
     *mut u64,
 ) -> crate::base::Status};
 
-pub type ProtocolSetPosition = eficall! {fn(
+pub type ProtocolSetPosition = eficall! {unsafe fn(
     *mut Protocol,
     u64,
 ) -> crate::base::Status};
 
-pub type ProtocolGetInfo = eficall! {fn(
+pub type ProtocolGetInfo = eficall! {unsafe fn(
     *mut Protocol,
     *mut crate::base::Guid,
     *mut usize,
     *mut core::ffi::c_void,
 ) -> crate::base::Status};
 
-pub type ProtocolSetInfo = eficall! {fn(
+pub type ProtocolSetInfo = eficall! {unsafe fn(
     *mut Protocol,
     *mut crate::base::Guid,
     usize,
     *mut core::ffi::c_void,
 ) -> crate::base::Status};
 
-pub type ProtocolFlush = eficall! {fn(
+pub type ProtocolFlush = eficall! {unsafe fn(
     *mut Protocol,
 ) -> crate::base::Status};
 
-pub type ProtocolOpenEx = eficall! {fn(
+pub type ProtocolOpenEx = eficall! {unsafe fn(
     *mut Protocol,
     *mut *mut Protocol,
     *mut crate::base::Char16,
@@ -148,17 +148,17 @@ pub type ProtocolOpenEx = eficall! {fn(
     *mut IoToken,
 ) -> crate::base::Status};
 
-pub type ProtocolReadEx = eficall! {fn(
+pub type ProtocolReadEx = eficall! {unsafe fn(
     *mut Protocol,
     *mut IoToken,
 ) -> crate::base::Status};
 
-pub type ProtocolWriteEx = eficall! {fn(
+pub type ProtocolWriteEx = eficall! {unsafe fn(
     *mut Protocol,
     *mut IoToken,
 ) -> crate::base::Status};
 
-pub type ProtocolFlushEx = eficall! {fn(
+pub type ProtocolFlushEx = eficall! {unsafe fn(
     *mut Protocol,
     *mut IoToken,
 ) -> crate::base::Status};

--- a/src/protocols/graphics_output.rs
+++ b/src/protocols/graphics_output.rs
@@ -69,19 +69,19 @@ pub const BLT_BUFFER_TO_VIDEO: BltOperation = 0x00000002;
 pub const BLT_VIDEO_TO_VIDEO: BltOperation = 0x00000003;
 pub const BLT_OPERATION_MAX: BltOperation = 0x00000004;
 
-pub type ProtocolQueryMode = eficall! {fn(
+pub type ProtocolQueryMode = eficall! {unsafe fn(
     *mut Protocol,
     u32,
     *mut usize,
     *mut *mut ModeInformation,
 ) -> crate::base::Status};
 
-pub type ProtocolSetMode = eficall! {fn(
+pub type ProtocolSetMode = eficall! {unsafe fn(
     *mut Protocol,
     u32,
 ) -> crate::base::Status};
 
-pub type ProtocolBlt = eficall! {fn(
+pub type ProtocolBlt = eficall! {unsafe fn(
     *mut Protocol,
     *mut BltPixel,
     BltOperation,

--- a/src/protocols/hii_database.rs
+++ b/src/protocols/hii_database.rs
@@ -20,25 +20,25 @@ pub const SET_KEYBOARD_LAYOUT_EVENT_GUID: crate::base::Guid = crate::base::Guid:
     &[0x5a, 0x7a, 0x9b, 0xc2, 0x32, 0xdf],
 );
 
-pub type ProtocolNewPackageList = eficall! {fn(
+pub type ProtocolNewPackageList = eficall! {unsafe fn(
     *const Protocol,
     *const crate::hii::PackageListHeader,
     crate::base::Handle,
     *mut crate::hii::Handle,
 ) -> crate::base::Status};
 
-pub type ProtocolRemovePackageList = eficall! {fn(
+pub type ProtocolRemovePackageList = eficall! {unsafe fn(
     *const Protocol,
     crate::hii::Handle,
 ) -> crate::base::Status};
 
-pub type ProtocolUpdatePackageList = eficall! {fn(
+pub type ProtocolUpdatePackageList = eficall! {unsafe fn(
     *const Protocol,
     crate::hii::Handle,
     *const crate::hii::PackageListHeader,
 ) -> crate::base::Status};
 
-pub type ProtocolListPackageLists = eficall! {fn(
+pub type ProtocolListPackageLists = eficall! {unsafe fn(
     *const Protocol,
     u8,
     *const crate::base::Guid,
@@ -46,14 +46,14 @@ pub type ProtocolListPackageLists = eficall! {fn(
     *mut crate::hii::Handle,
 ) -> crate::base::Status};
 
-pub type ProtocolExportPackageLists = eficall! {fn(
+pub type ProtocolExportPackageLists = eficall! {unsafe fn(
     *const Protocol,
     crate::hii::Handle,
     *mut usize,
     *mut crate::hii::PackageListHeader,
 ) -> crate::base::Status};
 
-pub type ProtocolRegisterPackageNotify = eficall! {fn(
+pub type ProtocolRegisterPackageNotify = eficall! {unsafe fn(
     *const Protocol,
     u8,
     *const crate::base::Guid,
@@ -62,30 +62,30 @@ pub type ProtocolRegisterPackageNotify = eficall! {fn(
     *mut crate::base::Handle,
 ) -> crate::base::Status};
 
-pub type ProtocolUnregisterPackageNotify = eficall! {fn(
+pub type ProtocolUnregisterPackageNotify = eficall! {unsafe fn(
     *const Protocol,
     crate::base::Handle,
 ) -> crate::base::Status};
 
-pub type ProtocolFindKeyboardLayouts = eficall! {fn(
+pub type ProtocolFindKeyboardLayouts = eficall! {unsafe fn(
     *const Protocol,
     *mut u16,
     *mut crate::base::Guid,
 ) -> crate::base::Status};
 
-pub type ProtocolGetKeyboardLayout = eficall! {fn(
+pub type ProtocolGetKeyboardLayout = eficall! {unsafe fn(
     *const Protocol,
     *const crate::base::Guid,
     *mut u16,
     *mut KeyboardLayout,
 ) -> crate::base::Status};
 
-pub type ProtocolSetKeyboardLayout = eficall! {fn(
+pub type ProtocolSetKeyboardLayout = eficall! {unsafe fn(
     *const Protocol,
     *mut crate::base::Guid,
 ) -> crate::base::Status};
 
-pub type ProtocolGetPackageListHandle = eficall! {fn(
+pub type ProtocolGetPackageListHandle = eficall! {unsafe fn(
     *const Protocol,
     crate::hii::Handle,
     *mut crate::base::Handle,
@@ -283,7 +283,7 @@ pub const LEFT_LOGO_MODIFIER: u16 = 0x0027;
 pub const RIGHT_LOGO_MODIFIER: u16 = 0x0028;
 pub const MENU_MODIFIER: u16 = 0x0029;
 
-pub type Notify = eficall! {fn(
+pub type Notify = eficall! {unsafe fn(
     u8,
     *const crate::base::Guid,
     *const crate::hii::PackageHeader,

--- a/src/protocols/hii_font.rs
+++ b/src/protocols/hii_font.rs
@@ -9,7 +9,7 @@ pub const PROTOCOL_GUID: crate::base::Guid = crate::base::Guid::from_fields(
     &[0x7e, 0xd6, 0x5a, 0x08, 0x43, 0x24],
 );
 
-pub type ProtocolStringToImage = eficall! {fn(
+pub type ProtocolStringToImage = eficall! {unsafe fn(
     *const Protocol,
     OutFlags,
     String,
@@ -22,7 +22,7 @@ pub type ProtocolStringToImage = eficall! {fn(
     *mut usize,
 ) -> crate::base::Status};
 
-pub type ProtocolStringIdToImage = eficall! {fn(
+pub type ProtocolStringIdToImage = eficall! {unsafe fn(
     *const Protocol,
     OutFlags,
     crate::hii::Handle,
@@ -37,7 +37,7 @@ pub type ProtocolStringIdToImage = eficall! {fn(
     *mut usize,
 ) -> crate::base::Status};
 
-pub type ProtocolGetGlyph = eficall! {fn(
+pub type ProtocolGetGlyph = eficall! {unsafe fn(
     *const Protocol,
     crate::base::Char16,
     *const super::hii_font_ex::DisplayInfo,
@@ -45,7 +45,7 @@ pub type ProtocolGetGlyph = eficall! {fn(
     *mut usize,
 ) -> crate::base::Status};
 
-pub type ProtocolGetFontInfo = eficall! {fn(
+pub type ProtocolGetFontInfo = eficall! {unsafe fn(
     *const Protocol,
     *mut Handle,
     *const super::hii_font_ex::DisplayInfo,

--- a/src/protocols/hii_font_ex.rs
+++ b/src/protocols/hii_font_ex.rs
@@ -9,7 +9,7 @@ pub const PROTOCOL_GUID: crate::base::Guid = crate::base::Guid::from_fields(
     &[0xc8, 0xf3, 0x37, 0x18, 0x07, 0x3f],
 );
 
-pub type ProtocolStringToImageEx = eficall! {fn(
+pub type ProtocolStringToImageEx = eficall! {unsafe fn(
     *const Protocol,
     super::hii_font::OutFlags,
     super::hii_font::String,
@@ -22,7 +22,7 @@ pub type ProtocolStringToImageEx = eficall! {fn(
     *mut usize,
 ) -> crate::base::Status};
 
-pub type ProtocolStringIdToImageEx = eficall! {fn(
+pub type ProtocolStringIdToImageEx = eficall! {unsafe fn(
     *const Protocol,
     super::hii_font::OutFlags,
     crate::hii::Handle,
@@ -37,7 +37,7 @@ pub type ProtocolStringIdToImageEx = eficall! {fn(
     *mut usize,
 ) -> crate::base::Status};
 
-pub type ProtocolGetGlyphEx = eficall! {fn(
+pub type ProtocolGetGlyphEx = eficall! {unsafe fn(
     *const Protocol,
     crate::base::Char16,
     *const DisplayInfo,
@@ -45,7 +45,7 @@ pub type ProtocolGetGlyphEx = eficall! {fn(
     usize,
 ) -> crate::base::Status};
 
-pub type ProtocolGetFontInfoEx = eficall! {fn(
+pub type ProtocolGetFontInfoEx = eficall! {unsafe fn(
     *const Protocol,
     *mut super::hii_font::Handle,
     *const DisplayInfo,
@@ -53,7 +53,7 @@ pub type ProtocolGetFontInfoEx = eficall! {fn(
     super::hii_font::String,
 ) -> crate::base::Status};
 
-pub type ProtocolGetGlyphInfo = eficall! {fn(
+pub type ProtocolGetGlyphInfo = eficall! {unsafe fn(
     *const Protocol,
     crate::base::Char16,
     *const DisplayInfo,

--- a/src/protocols/hii_string.rs
+++ b/src/protocols/hii_string.rs
@@ -9,7 +9,7 @@ pub const PROTOCOL_GUID: crate::base::Guid = crate::base::Guid::from_fields(
     &[0x98, 0xd1, 0x77, 0x50, 0x32, 0x2a],
 );
 
-pub type ProtocolNewString = eficall! {fn(
+pub type ProtocolNewString = eficall! {unsafe fn(
     *const Protocol,
     crate::hii::Handle,
     *mut crate::hii::StringId,
@@ -19,7 +19,7 @@ pub type ProtocolNewString = eficall! {fn(
     *const Info,
 ) -> crate::base::Status};
 
-pub type ProtocolGetString = eficall! {fn(
+pub type ProtocolGetString = eficall! {unsafe fn(
     *const Protocol,
     *const crate::base::Char8,
     crate::hii::Handle,
@@ -29,7 +29,7 @@ pub type ProtocolGetString = eficall! {fn(
     *mut *mut Info,
 ) -> crate::base::Status};
 
-pub type ProtocolSetString = eficall! {fn(
+pub type ProtocolSetString = eficall! {unsafe fn(
     *const Protocol,
     crate::hii::Handle,
     crate::hii::StringId,
@@ -38,14 +38,14 @@ pub type ProtocolSetString = eficall! {fn(
     *const Info,
 ) -> crate::base::Status};
 
-pub type ProtocolGetLanguages = eficall! {fn(
+pub type ProtocolGetLanguages = eficall! {unsafe fn(
     *const Protocol,
     crate::hii::Handle,
     *mut crate::base::Char8,
     *mut usize,
 ) -> crate::base::Status};
 
-pub type ProtocolGetSecondaryLanguages = eficall! {fn(
+pub type ProtocolGetSecondaryLanguages = eficall! {unsafe fn(
     *const Protocol,
     crate::hii::Handle,
     *const crate::base::Char8,

--- a/src/protocols/ip4.rs
+++ b/src/protocols/ip4.rs
@@ -144,25 +144,25 @@ pub struct OverrideData {
     pub do_not_fragment: crate::base::Boolean,
 }
 
-pub type ProtocolGetModeData = eficall! {fn(
+pub type ProtocolGetModeData = eficall! {unsafe fn(
     *mut Protocol,
     *mut ModeData,
     *mut crate::protocols::managed_network::ConfigData,
     *mut crate::protocols::simple_network::Mode,
 ) -> crate::base::Status};
 
-pub type ProtocolConfigure = eficall! {fn(
+pub type ProtocolConfigure = eficall! {unsafe fn(
     *mut Protocol,
     *mut ConfigData,
 ) -> crate::base::Status};
 
-pub type ProtocolGroups = eficall! {fn(
+pub type ProtocolGroups = eficall! {unsafe fn(
     *mut Protocol,
     crate::base::Boolean,
     *mut crate::base::Ipv4Address,
 ) -> crate::base::Status};
 
-pub type ProtocolRoutes = eficall! {fn(
+pub type ProtocolRoutes = eficall! {unsafe fn(
     *mut Protocol,
     crate::base::Boolean,
     *mut crate::base::Ipv4Address,
@@ -170,22 +170,22 @@ pub type ProtocolRoutes = eficall! {fn(
     *mut crate::base::Ipv4Address,
 ) -> crate::base::Status};
 
-pub type ProtocolTransmit = eficall! {fn(
+pub type ProtocolTransmit = eficall! {unsafe fn(
     *mut Protocol,
     *mut CompletionToken,
 ) -> crate::base::Status};
 
-pub type ProtocolReceive = eficall! {fn(
+pub type ProtocolReceive = eficall! {unsafe fn(
     *mut Protocol,
     *mut CompletionToken,
 ) -> crate::base::Status};
 
-pub type ProtocolCancel = eficall! {fn(
+pub type ProtocolCancel = eficall! {unsafe fn(
     *mut Protocol,
     *mut CompletionToken,
 ) -> crate::base::Status};
 
-pub type ProtocolPoll = eficall! {fn(
+pub type ProtocolPoll = eficall! {unsafe fn(
     *mut Protocol,
 ) -> crate::base::Status};
 

--- a/src/protocols/ip6.rs
+++ b/src/protocols/ip6.rs
@@ -196,25 +196,25 @@ pub struct OverrideData {
     pub flow_label: u32,
 }
 
-pub type ProtocolGetModeData = eficall! {fn(
+pub type ProtocolGetModeData = eficall! {unsafe fn(
     *mut Protocol,
     *mut ModeData,
     *mut crate::protocols::managed_network::ConfigData,
     *mut crate::protocols::simple_network::Mode,
 ) -> crate::base::Status};
 
-pub type ProtocolConfigure = eficall! {fn(
+pub type ProtocolConfigure = eficall! {unsafe fn(
     *mut Protocol,
     *mut ConfigData,
 ) -> crate::base::Status};
 
-pub type ProtocolGroups = eficall! {fn(
+pub type ProtocolGroups = eficall! {unsafe fn(
     *mut Protocol,
     crate::base::Boolean,
     *mut crate::base::Ipv6Address,
 ) -> crate::base::Status};
 
-pub type ProtocolRoutes = eficall! {fn(
+pub type ProtocolRoutes = eficall! {unsafe fn(
     *mut Protocol,
     crate::base::Boolean,
     *mut crate::base::Ipv6Address,
@@ -222,7 +222,7 @@ pub type ProtocolRoutes = eficall! {fn(
     *mut crate::base::Ipv6Address,
 ) -> crate::base::Status};
 
-pub type ProtocolNeighbors = eficall! {fn(
+pub type ProtocolNeighbors = eficall! {unsafe fn(
     *mut Protocol,
     crate::base::Boolean,
     *mut crate::base::Ipv6Address,
@@ -231,22 +231,22 @@ pub type ProtocolNeighbors = eficall! {fn(
     crate::base::Boolean,
 ) -> crate::base::Status};
 
-pub type ProtocolTransmit = eficall! {fn(
+pub type ProtocolTransmit = eficall! {unsafe fn(
     *mut Protocol,
     *mut CompletionToken,
 ) -> crate::base::Status};
 
-pub type ProtocolReceive = eficall! {fn(
+pub type ProtocolReceive = eficall! {unsafe fn(
     *mut Protocol,
     *mut CompletionToken,
 ) -> crate::base::Status};
 
-pub type ProtocolCancel = eficall! {fn(
+pub type ProtocolCancel = eficall! {unsafe fn(
     *mut Protocol,
     *mut CompletionToken,
 ) -> crate::base::Status};
 
-pub type ProtocolPoll = eficall! {fn(
+pub type ProtocolPoll = eficall! {unsafe fn(
     *mut Protocol,
 ) -> crate::base::Status};
 

--- a/src/protocols/load_file.rs
+++ b/src/protocols/load_file.rs
@@ -12,7 +12,7 @@ pub const PROTOCOL_GUID: crate::base::Guid = crate::base::Guid::from_fields(
     &[0x00, 0xa0, 0xc9, 0x69, 0x72, 0x3b],
 );
 
-pub type ProtocolLoadFile = eficall! {fn(
+pub type ProtocolLoadFile = eficall! {unsafe fn(
   *mut Protocol,
   *mut crate::protocols::device_path::Protocol,
   crate::base::Boolean,

--- a/src/protocols/loaded_image.rs
+++ b/src/protocols/loaded_image.rs
@@ -14,7 +14,7 @@ pub const PROTOCOL_GUID: crate::base::Guid = crate::base::Guid::from_fields(
 
 pub const REVISION: u32 = 0x00001000u32;
 
-pub type ProtocolUnload = eficall! {fn(
+pub type ProtocolUnload = eficall! {unsafe fn(
     crate::base::Handle,
 ) -> crate::base::Status};
 

--- a/src/protocols/managed_network.rs
+++ b/src/protocols/managed_network.rs
@@ -91,46 +91,46 @@ pub struct FragmentData {
     pub fragment_buffer: *mut core::ffi::c_void,
 }
 
-pub type ProtocolGetModeData = eficall! {fn(
+pub type ProtocolGetModeData = eficall! {unsafe fn(
     *mut Protocol,
     *mut ConfigData,
     *mut crate::protocols::simple_network::Mode,
 ) -> crate::base::Status};
 
-pub type ProtocolConfigure = eficall! {fn(
+pub type ProtocolConfigure = eficall! {unsafe fn(
     *mut Protocol,
     *mut ConfigData,
 ) -> crate::base::Status};
 
-pub type ProtocolMcastIpToMac = eficall! {fn(
+pub type ProtocolMcastIpToMac = eficall! {unsafe fn(
     *mut Protocol,
     crate::base::Boolean,
     *mut crate::base::IpAddress,
     *mut crate::base::MacAddress,
 ) -> crate::base::Status};
 
-pub type ProtocolGroups = eficall! {fn(
+pub type ProtocolGroups = eficall! {unsafe fn(
     *mut Protocol,
     crate::base::Boolean,
     *mut crate::base::MacAddress,
 ) -> crate::base::Status};
 
-pub type ProtocolTransmit = eficall! {fn(
+pub type ProtocolTransmit = eficall! {unsafe fn(
     *mut Protocol,
     *mut CompletionToken,
 ) -> crate::base::Status};
 
-pub type ProtocolReceive = eficall! {fn(
+pub type ProtocolReceive = eficall! {unsafe fn(
     *mut Protocol,
     *mut CompletionToken,
 ) -> crate::base::Status};
 
-pub type ProtocolCancel = eficall! {fn(
+pub type ProtocolCancel = eficall! {unsafe fn(
     *mut Protocol,
     *mut CompletionToken,
 ) -> crate::base::Status};
 
-pub type ProtocolPoll = eficall! {fn(
+pub type ProtocolPoll = eficall! {unsafe fn(
     *mut Protocol,
 ) -> crate::base::Status};
 

--- a/src/protocols/memory_attribute.rs
+++ b/src/protocols/memory_attribute.rs
@@ -11,21 +11,21 @@ pub const PROTOCOL_GUID: crate::base::Guid = crate::base::Guid::from_fields(
     &[0xbf, 0x1d, 0x57, 0xd0, 0xb1, 0x89],
 );
 
-pub type GetMemoryAttributes = eficall! {fn(
+pub type GetMemoryAttributes = eficall! {unsafe fn(
     *mut Protocol,
     crate::base::PhysicalAddress,
     u64,
     *mut u64,
 ) -> crate::base::Status};
 
-pub type SetMemoryAttributes = eficall! {fn(
+pub type SetMemoryAttributes = eficall! {unsafe fn(
     *mut Protocol,
     crate::base::PhysicalAddress,
     u64,
     u64,
 ) -> crate::base::Status};
 
-pub type ClearMemoryAttributes = eficall! {fn(
+pub type ClearMemoryAttributes = eficall! {unsafe fn(
     *mut Protocol,
     crate::base::PhysicalAddress,
     u64,

--- a/src/protocols/mp_services.rs
+++ b/src/protocols/mp_services.rs
@@ -57,21 +57,21 @@ pub struct ProcessorInformation {
     pub extended_information: ExtendedProcessorInformation,
 }
 
-pub type ApProcedure = eficall! {fn(*mut core::ffi::c_void)};
+pub type ApProcedure = eficall! {unsafe fn(*mut core::ffi::c_void)};
 
-pub type GetNumberOfProcessors = eficall! {fn(
+pub type GetNumberOfProcessors = eficall! {unsafe fn(
     *mut Protocol,
     *mut usize,
     *mut usize,
 ) -> crate::base::Status};
 
-pub type GetProcessorInfo = eficall! {fn(
+pub type GetProcessorInfo = eficall! {unsafe fn(
     *mut Protocol,
     usize,
     *mut ProcessorInformation,
 ) -> crate::base::Status};
 
-pub type StartupAllAps = eficall! {fn(
+pub type StartupAllAps = eficall! {unsafe fn(
     *mut Protocol,
     ApProcedure,
     crate::base::Boolean,
@@ -81,7 +81,7 @@ pub type StartupAllAps = eficall! {fn(
     *mut *mut usize,
 ) -> crate::base::Status};
 
-pub type StartupThisAp = eficall! {fn(
+pub type StartupThisAp = eficall! {unsafe fn(
     *mut Protocol,
     ApProcedure,
     usize,
@@ -91,20 +91,20 @@ pub type StartupThisAp = eficall! {fn(
     *mut crate::base::Boolean,
 ) -> crate::base::Status};
 
-pub type SwitchBsp = eficall! {fn(
+pub type SwitchBsp = eficall! {unsafe fn(
     *mut Protocol,
     usize,
     crate::base::Boolean,
 ) -> crate::base::Status};
 
-pub type EnableDisableAp = eficall! {fn(
+pub type EnableDisableAp = eficall! {unsafe fn(
     *mut Protocol,
     usize,
     crate::base::Boolean,
     *mut u32,
 ) -> crate::base::Status};
 
-pub type WhoAmI = eficall! {fn(
+pub type WhoAmI = eficall! {unsafe fn(
     *mut Protocol,
     *mut usize,
 ) -> crate::base::Status};

--- a/src/protocols/pci_io.rs
+++ b/src/protocols/pci_io.rs
@@ -68,7 +68,7 @@ pub const ATTRIBUTE_OPERATION_MAXIMUM: AttributeOperation = 0x00000005;
 
 pub const PASS_THROUGH_BAR: u8 = 0xff;
 
-pub type ProtocolPollIoMem = eficall! {fn(
+pub type ProtocolPollIoMem = eficall! {unsafe fn(
     *mut Protocol,
     Width,
     u8,
@@ -79,7 +79,7 @@ pub type ProtocolPollIoMem = eficall! {fn(
     *mut u64,
 ) -> crate::base::Status};
 
-pub type ProtocolIoMem = eficall! {fn(
+pub type ProtocolIoMem = eficall! {unsafe fn(
     *mut Protocol,
     Width,
     u8,
@@ -88,7 +88,7 @@ pub type ProtocolIoMem = eficall! {fn(
     *mut core::ffi::c_void,
 ) -> crate::base::Status};
 
-pub type ProtocolConfig = eficall! {fn(
+pub type ProtocolConfig = eficall! {unsafe fn(
     *mut Protocol,
     Width,
     u32,
@@ -96,7 +96,7 @@ pub type ProtocolConfig = eficall! {fn(
     *mut core::ffi::c_void,
 ) -> crate::base::Status};
 
-pub type ProtocolCopyMem = eficall! {fn(
+pub type ProtocolCopyMem = eficall! {unsafe fn(
     *mut Protocol,
     Width,
     u8,
@@ -106,7 +106,7 @@ pub type ProtocolCopyMem = eficall! {fn(
     usize,
 ) -> crate::base::Status};
 
-pub type ProtocolMap = eficall! {fn(
+pub type ProtocolMap = eficall! {unsafe fn(
     *mut Protocol,
     Operation,
     *mut core::ffi::c_void,
@@ -115,12 +115,12 @@ pub type ProtocolMap = eficall! {fn(
     *mut *mut core::ffi::c_void,
 ) -> crate::base::Status};
 
-pub type ProtocolUnmap = eficall! {fn(
+pub type ProtocolUnmap = eficall! {unsafe fn(
     *mut Protocol,
     *mut core::ffi::c_void,
 ) -> crate::base::Status};
 
-pub type ProtocolAllocateBuffer = eficall! {fn(
+pub type ProtocolAllocateBuffer = eficall! {unsafe fn(
     *mut Protocol,
     crate::system::AllocateType,
     crate::system::MemoryType,
@@ -129,17 +129,17 @@ pub type ProtocolAllocateBuffer = eficall! {fn(
     Attribute,
 ) -> crate::base::Status};
 
-pub type ProtocolFreeBuffer = eficall! {fn(
+pub type ProtocolFreeBuffer = eficall! {unsafe fn(
     *mut Protocol,
     usize,
     *mut core::ffi::c_void,
 ) -> crate::base::Status};
 
-pub type ProtocolFlush = eficall! {fn(
+pub type ProtocolFlush = eficall! {unsafe fn(
     *mut Protocol,
 ) -> crate::base::Status};
 
-pub type ProtocolGetLocation = eficall! {fn(
+pub type ProtocolGetLocation = eficall! {unsafe fn(
     *mut Protocol,
     *mut usize,
     *mut usize,
@@ -147,21 +147,21 @@ pub type ProtocolGetLocation = eficall! {fn(
     *mut usize,
 ) -> crate::base::Status};
 
-pub type ProtocolAttributes = eficall! {fn(
+pub type ProtocolAttributes = eficall! {unsafe fn(
     *mut Protocol,
     AttributeOperation,
     Attribute,
     *mut Attribute,
 ) -> crate::base::Status};
 
-pub type ProtocolGetBarAttributes = eficall! {fn(
+pub type ProtocolGetBarAttributes = eficall! {unsafe fn(
     *mut Protocol,
     u8,
     *mut Attribute,
     *mut *mut core::ffi::c_void,
 ) -> crate::base::Status};
 
-pub type ProtocolSetBarAttributes = eficall! {fn(
+pub type ProtocolSetBarAttributes = eficall! {unsafe fn(
     *mut Protocol,
     Attribute,
     u8,

--- a/src/protocols/platform_driver_override.rs
+++ b/src/protocols/platform_driver_override.rs
@@ -19,19 +19,19 @@ pub const PROTOCOL_GUID: crate::base::Guid = crate::base::Guid::from_fields(
     &[0x00, 0x90, 0x27, 0x3f, 0xc1, 0x4d],
 );
 
-pub type ProtocolGetDriver = eficall! {fn(
+pub type ProtocolGetDriver = eficall! {unsafe fn(
     *mut Protocol,
     crate::base::Handle,
     *mut crate::base::Handle,
 ) -> crate::base::Status};
 
-pub type ProtocolGetDriverPath = eficall! {fn(
+pub type ProtocolGetDriverPath = eficall! {unsafe fn(
     *mut Protocol,
     crate::base::Handle,
     *mut *mut crate::protocols::device_path::Protocol
 ) -> crate::base::Status};
 
-pub type ProtocolDriverLoaded = eficall! {fn(
+pub type ProtocolDriverLoaded = eficall! {unsafe fn(
     *mut Protocol,
     crate::base::Handle,
     *mut crate::protocols::device_path::Protocol,

--- a/src/protocols/rng.rs
+++ b/src/protocols/rng.rs
@@ -63,13 +63,13 @@ pub const ALGORITHM_RAW: Algorithm = crate::base::Guid::from_fields(
     &[0x7f, 0xfd, 0xc4, 0xb6, 0x85, 0x61],
 );
 
-pub type ProtocolGetInfo = eficall! {fn(
+pub type ProtocolGetInfo = eficall! {unsafe fn(
     *mut Protocol,
     *mut usize,
     *mut Algorithm,
 ) -> crate::base::Status};
 
-pub type ProtocolGetRng = eficall! {fn(
+pub type ProtocolGetRng = eficall! {unsafe fn(
     *mut Protocol,
     *mut Algorithm,
     usize,

--- a/src/protocols/service_binding.rs
+++ b/src/protocols/service_binding.rs
@@ -3,12 +3,12 @@
 //! Provides services that are required to create and destroy child handles
 //! that support a given set of protocols.
 
-pub type ProtocolCreateChild = eficall! {fn(
+pub type ProtocolCreateChild = eficall! {unsafe fn(
     *mut Protocol,
     *mut crate::base::Handle,
 ) -> crate::base::Status};
 
-pub type ProtocolDestroyChild = eficall! {fn(
+pub type ProtocolDestroyChild = eficall! {unsafe fn(
     *mut Protocol,
     crate::base::Handle,
 ) -> crate::base::Status};

--- a/src/protocols/shell.rs
+++ b/src/protocols/shell.rs
@@ -36,82 +36,82 @@ pub struct FileInfo {
     pub info: *mut crate::protocols::file::Info,
 }
 
-pub type Execute = eficall! {fn(
+pub type Execute = eficall! {unsafe fn(
     *mut crate::base::Handle,
     *mut crate::base::Char16,
     *mut *mut crate::base::Char16,
     *mut crate::base::Status,
 ) -> crate::base::Status};
 
-pub type GetEnv = eficall! {fn(
+pub type GetEnv = eficall! {unsafe fn(
     *mut crate::base::Char16,
 ) -> *mut crate::base::Char16};
 
-pub type SetEnv = eficall! {fn(
+pub type SetEnv = eficall! {unsafe fn(
     *mut crate::base::Char16,
     *mut crate::base::Char16,
     crate::base::Boolean,
 ) -> crate::base::Status};
 
-pub type GetAlias = eficall! {fn(
+pub type GetAlias = eficall! {unsafe fn(
     *mut crate::base::Char16,
     *mut crate::base::Boolean,
 ) -> *mut crate::base::Char16};
 
-pub type SetAlias = eficall! {fn(
+pub type SetAlias = eficall! {unsafe fn(
     *mut crate::base::Char16,
     *mut crate::base::Char16,
     crate::base::Boolean,
     crate::base::Boolean,
 ) -> crate::base::Status};
 
-pub type GetHelpText = eficall! {fn(
+pub type GetHelpText = eficall! {unsafe fn(
     *mut crate::base::Char16,
     *mut crate::base::Char16,
     *mut *mut crate::base::Char16,
 ) -> crate::base::Status};
 
-pub type GetDevicePathFromMap = eficall! {fn(
+pub type GetDevicePathFromMap = eficall! {unsafe fn(
     *mut crate::base::Char16,
 ) -> *mut crate::protocols::device_path::Protocol};
 
-pub type GetMapFromDevicePath = eficall! {fn(
+pub type GetMapFromDevicePath = eficall! {unsafe fn(
     *mut *mut crate::protocols::device_path::Protocol,
 ) -> *mut crate::base::Char16};
 
-pub type GetDevicePathFromFilePath = eficall! {fn(
+pub type GetDevicePathFromFilePath = eficall! {unsafe fn(
     *mut crate::base::Char16,
 ) -> *mut crate::protocols::device_path::Protocol};
 
-pub type GetFilePathFromDevicePath = eficall! {fn(
+pub type GetFilePathFromDevicePath = eficall! {unsafe fn(
     *mut crate::protocols::device_path::Protocol,
 ) -> *mut crate::base::Char16};
 
-pub type SetMap = eficall! {fn(
+pub type SetMap = eficall! {unsafe fn(
     *mut crate::protocols::device_path::Protocol,
     *mut crate::base::Char16,
 ) -> crate::base::Status};
 
-pub type GetCurDir = eficall! {fn(
+pub type GetCurDir = eficall! {unsafe fn(
     *mut crate::base::Char16,
 ) -> *mut crate::base::Char16};
 
-pub type SetCurDir = eficall! {fn(
+pub type SetCurDir = eficall! {unsafe fn(
     *mut crate::base::Char16,
     *mut crate::base::Char16,
 ) -> crate::base::Status};
 
-pub type OpenFileList = eficall! {fn(
+pub type OpenFileList = eficall! {unsafe fn(
     *mut crate::base::Char16,
     u64,
     *mut *mut FileInfo,
 ) -> crate::base::Status};
 
-pub type FreeFileList = eficall! {fn(
+pub type FreeFileList = eficall! {unsafe fn(
     *mut *mut FileInfo,
 ) -> crate::base::Status};
 
-pub type RemoveDupInFileList = eficall! {fn(
+pub type RemoveDupInFileList = eficall! {unsafe fn(
     *mut *mut FileInfo,
 ) -> crate::base::Status};
 
@@ -125,113 +125,113 @@ pub type DisablePageBreak = eficall! {fn()};
 
 pub type GetPageBreak = eficall! {fn() -> crate::base::Boolean};
 
-pub type GetDeviceName = eficall! {fn(
+pub type GetDeviceName = eficall! {unsafe fn(
     crate::base::Handle,
     DeviceNameFlags,
     *mut crate::base::Char8,
     *mut *mut crate::base::Char16,
 ) -> crate::base::Status};
 
-pub type GetFileInfo = eficall! {fn(
+pub type GetFileInfo = eficall! {unsafe fn(
     FileHandle,
 ) -> *mut crate::protocols::file::Info};
 
-pub type SetFileInfo = eficall! {fn(
+pub type SetFileInfo = eficall! {unsafe fn(
     FileHandle,
     *mut crate::protocols::file::Info
 ) -> crate::base::Status};
 
-pub type OpenFileByName = eficall! {fn(
+pub type OpenFileByName = eficall! {unsafe fn(
     *mut crate::base::Char16,
     *mut FileHandle,
     u64,
 ) -> crate::base::Status};
 
-pub type CloseFile = eficall! {fn(
+pub type CloseFile = eficall! {unsafe fn(
     FileHandle,
 ) -> crate::base::Status};
 
-pub type CreateFile = eficall! {fn(
+pub type CreateFile = eficall! {unsafe fn(
     *mut crate::base::Char16,
     u64,
     *mut FileHandle,
 ) -> crate::base::Status};
 
-pub type ReadFile = eficall! {fn(
+pub type ReadFile = eficall! {unsafe fn(
     FileHandle,
     *mut usize,
     *mut core::ffi::c_void,
 ) -> crate::base::Status};
 
-pub type WriteFile = eficall! {fn(
+pub type WriteFile = eficall! {unsafe fn(
     FileHandle,
     *mut usize,
     *mut core::ffi::c_void,
 ) -> crate::base::Status};
 
-pub type DeleteFile = eficall! {fn(
+pub type DeleteFile = eficall! {unsafe fn(
     FileHandle,
 ) -> crate::base::Status};
 
-pub type DeleteFileByName = eficall! {fn(
+pub type DeleteFileByName = eficall! {unsafe fn(
     *mut crate::base::Char16,
 ) -> crate::base::Status};
 
-pub type GetFilePosition = eficall! {fn(
+pub type GetFilePosition = eficall! {unsafe fn(
     FileHandle,
     *mut u64,
 ) -> crate::base::Status};
 
-pub type SetFilePosition = eficall! {fn(
+pub type SetFilePosition = eficall! {unsafe fn(
     FileHandle,
     u64,
 ) -> crate::base::Status};
 
-pub type FlushFile = eficall! {fn(
+pub type FlushFile = eficall! {unsafe fn(
     FileHandle,
 ) -> crate::base::Status};
 
-pub type FindFiles = eficall! {fn(
+pub type FindFiles = eficall! {unsafe fn(
     *mut crate::base::Char16,
     *mut *mut FileInfo,
 ) -> crate::base::Status};
 
-pub type FindFilesInDir = eficall! {fn(
+pub type FindFilesInDir = eficall! {unsafe fn(
     FileHandle,
     *mut *mut FileInfo,
 ) -> crate::base::Status};
 
-pub type GetFileSize = eficall! {fn(
+pub type GetFileSize = eficall! {unsafe fn(
     FileHandle,
     *mut u64,
 ) -> crate::base::Status};
 
-pub type OpenRoot = eficall! {fn(
+pub type OpenRoot = eficall! {unsafe fn(
     *mut crate::protocols::device_path::Protocol,
     *mut FileHandle,
 ) -> crate::base::Status};
 
-pub type OpenRootByHandle = eficall! {fn(
+pub type OpenRootByHandle = eficall! {unsafe fn(
     crate::base::Handle,
     *mut FileHandle,
 ) -> crate::base::Status};
 
-pub type RegisterGuidName = eficall! {fn(
+pub type RegisterGuidName = eficall! {unsafe fn(
     *mut crate::base::Guid,
     *mut crate::base::Char16,
 ) -> crate::base::Status};
 
-pub type GetGuidName = eficall! {fn(
+pub type GetGuidName = eficall! {unsafe fn(
     *mut crate::base::Guid,
     *mut *mut crate::base::Char16,
 ) -> crate::base::Status};
 
-pub type GetGuidFromName = eficall! {fn(
+pub type GetGuidFromName = eficall! {unsafe fn(
     *mut crate::base::Char16,
     *mut crate::base::Guid,
 ) -> crate::base::Status};
 
-pub type GetEnvEx = eficall! {fn(
+pub type GetEnvEx = eficall! {unsafe fn(
     *mut crate::base::Char16,
     *mut u32,
 ) -> *mut crate::base::Char16};

--- a/src/protocols/shell_dynamic_command.rs
+++ b/src/protocols/shell_dynamic_command.rs
@@ -13,14 +13,14 @@ pub const PROTOCOL_GUID: crate::base::Guid = crate::base::Guid::from_fields(
     &[0xa3, 0xdf, 0xac, 0x8a, 0x27, 0xc3],
 );
 
-pub type CommandHandler = eficall! {fn(
+pub type CommandHandler = eficall! {unsafe fn(
     *mut Protocol,
     *mut crate::system::SystemTable,
     *mut shell_parameters::Protocol,
     *mut shell::Protocol,
 ) -> crate::base::Status};
 
-pub type CommandGetHelp = eficall! {fn(
+pub type CommandGetHelp = eficall! {unsafe fn(
     *mut Protocol,
     *mut crate::base::Char8,
 ) -> crate::base::Status};

--- a/src/protocols/simple_file_system.rs
+++ b/src/protocols/simple_file_system.rs
@@ -14,7 +14,7 @@ pub const PROTOCOL_GUID: crate::base::Guid = crate::base::Guid::from_fields(
 
 pub const REVISION: u64 = 0x0000000000010000u64;
 
-pub type ProtocolOpenVolume = eficall! {fn(
+pub type ProtocolOpenVolume = eficall! {unsafe fn(
     *mut Protocol,
     *mut *mut crate::protocols::file::Protocol,
 ) -> crate::base::Status};

--- a/src/protocols/simple_network.rs
+++ b/src/protocols/simple_network.rs
@@ -89,30 +89,30 @@ pub struct Statistics {
     pub tx_retry_frames: u64,
 }
 
-pub type ProtocolStart = eficall! {fn(
+pub type ProtocolStart = eficall! {unsafe fn(
     *mut Protocol,
 ) -> crate::base::Status};
 
-pub type ProtocolStop = eficall! {fn(
+pub type ProtocolStop = eficall! {unsafe fn(
     *mut Protocol,
 ) -> crate::base::Status};
 
-pub type ProtocolInitialize = eficall! {fn(
+pub type ProtocolInitialize = eficall! {unsafe fn(
     *mut Protocol,
     usize,
     usize,
 ) -> crate::base::Status};
 
-pub type ProtocolReset = eficall! {fn(
+pub type ProtocolReset = eficall! {unsafe fn(
     *mut Protocol,
     crate::base::Boolean,
 ) -> crate::base::Status};
 
-pub type ProtocolShutdown = eficall! {fn(
+pub type ProtocolShutdown = eficall! {unsafe fn(
     *mut Protocol,
 ) -> crate::base::Status};
 
-pub type ProtocolReceiveFilters = eficall! {fn(
+pub type ProtocolReceiveFilters = eficall! {unsafe fn(
     *mut Protocol,
     u32,
     u32,
@@ -121,27 +121,27 @@ pub type ProtocolReceiveFilters = eficall! {fn(
     *mut crate::base::MacAddress,
 ) -> crate::base::Status};
 
-pub type ProtocolStationAddress = eficall! {fn(
+pub type ProtocolStationAddress = eficall! {unsafe fn(
     *mut Protocol,
     crate::base::Boolean,
     *mut crate::base::MacAddress,
 ) -> crate::base::Status};
 
-pub type ProtocolStatistics = eficall! {fn(
+pub type ProtocolStatistics = eficall! {unsafe fn(
     *mut Protocol,
     crate::base::Boolean,
     *mut usize,
     *mut Statistics,
 ) -> crate::base::Status};
 
-pub type ProtocolMcastIpToMac = eficall! {fn(
+pub type ProtocolMcastIpToMac = eficall! {unsafe fn(
     *mut Protocol,
     crate::base::Boolean,
     *mut crate::base::IpAddress,
     *mut crate::base::MacAddress,
 ) -> crate::base::Status};
 
-pub type ProtocolNvData = eficall! {fn(
+pub type ProtocolNvData = eficall! {unsafe fn(
     *mut Protocol,
     crate::base::Boolean,
     usize,
@@ -149,13 +149,13 @@ pub type ProtocolNvData = eficall! {fn(
     *mut core::ffi::c_void,
 ) -> crate::base::Status};
 
-pub type ProtocolGetStatus = eficall! {fn(
+pub type ProtocolGetStatus = eficall! {unsafe fn(
     *mut Protocol,
     *mut u32,
     *mut *mut core::ffi::c_void,
 ) -> crate::base::Status};
 
-pub type ProtocolTransmit = eficall! {fn(
+pub type ProtocolTransmit = eficall! {unsafe fn(
     *mut Protocol,
     usize,
     usize,
@@ -165,7 +165,7 @@ pub type ProtocolTransmit = eficall! {fn(
     *mut u16,
 ) -> crate::base::Status};
 
-pub type ProtocolReceive = eficall! {fn(
+pub type ProtocolReceive = eficall! {unsafe fn(
     *mut Protocol,
     *mut usize,
     *mut usize,

--- a/src/protocols/simple_text_input.rs
+++ b/src/protocols/simple_text_input.rs
@@ -20,12 +20,12 @@ pub struct InputKey {
     pub unicode_char: crate::base::Char16,
 }
 
-pub type ProtocolReset = eficall! {fn(
+pub type ProtocolReset = eficall! {unsafe fn(
     *mut Protocol,
     crate::base::Boolean,
 ) -> crate::base::Status};
 
-pub type ProtocolReadKeyStroke = eficall! {fn(
+pub type ProtocolReadKeyStroke = eficall! {unsafe fn(
     *mut Protocol,
     *mut InputKey,
 ) -> crate::base::Status};

--- a/src/protocols/simple_text_input_ex.rs
+++ b/src/protocols/simple_text_input_ex.rs
@@ -31,7 +31,7 @@ pub const NUM_LOCK_ACTIVE: u8 = 0x02u8;
 pub const CAPS_LOCK_ACTIVE: u8 = 0x04u8;
 
 pub type KeyToggleState = u8;
-pub type KeyNotifyFunction = eficall! {fn(*mut KeyData) -> crate::base::Status};
+pub type KeyNotifyFunction = eficall! {unsafe fn(*mut KeyData) -> crate::base::Status};
 
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Default)]
@@ -47,29 +47,29 @@ pub struct KeyData {
     pub key_state: KeyState,
 }
 
-pub type ProtocolReset = eficall! {fn(
+pub type ProtocolReset = eficall! {unsafe fn(
     *mut Protocol,
     crate::base::Boolean,
 ) -> crate::base::Status};
 
-pub type ProtocolReadKeyStrokeEx = eficall! {fn(
+pub type ProtocolReadKeyStrokeEx = eficall! {unsafe fn(
     *mut Protocol,
     *mut KeyData,
 ) -> crate::base::Status};
 
-pub type ProtocolSetState = eficall! {fn(
+pub type ProtocolSetState = eficall! {unsafe fn(
     *mut Protocol,
     *mut KeyToggleState,
 ) -> crate::base::Status};
 
-pub type ProtocolRegisterKeyNotify = eficall! {fn(
+pub type ProtocolRegisterKeyNotify = eficall! {unsafe fn(
     *mut Protocol,
     *mut KeyData,
     KeyNotifyFunction,
     *mut *mut core::ffi::c_void,
 ) -> crate::base::Status};
 
-pub type ProtocolUnregisterKeyNotify = eficall! {fn(
+pub type ProtocolUnregisterKeyNotify = eficall! {unsafe fn(
     *mut Protocol,
     *mut core::ffi::c_void,
 ) -> crate::base::Status};

--- a/src/protocols/simple_text_output.rs
+++ b/src/protocols/simple_text_output.rs
@@ -24,49 +24,49 @@ pub struct Mode {
     pub cursor_visible: crate::base::Boolean,
 }
 
-pub type ProtocolReset = eficall! {fn(
+pub type ProtocolReset = eficall! {unsafe fn(
     *mut Protocol,
     crate::base::Boolean,
 ) -> crate::base::Status};
 
-pub type ProtocolOutputString = eficall! {fn(
+pub type ProtocolOutputString = eficall! {unsafe fn(
     *mut Protocol,
     *mut crate::base::Char16,
 ) -> crate::base::Status};
 
-pub type ProtocolTestString = eficall! {fn(
+pub type ProtocolTestString = eficall! {unsafe fn(
     *mut Protocol,
     *mut crate::base::Char16,
 ) -> crate::base::Status};
 
-pub type ProtocolQueryMode = eficall! {fn(
+pub type ProtocolQueryMode = eficall! {unsafe fn(
     *mut Protocol,
     usize,
     *mut usize,
     *mut usize,
 ) -> crate::base::Status};
 
-pub type ProtocolSetMode = eficall! {fn(
+pub type ProtocolSetMode = eficall! {unsafe fn(
     *mut Protocol,
     usize,
 ) -> crate::base::Status};
 
-pub type ProtocolSetAttribute = eficall! {fn(
+pub type ProtocolSetAttribute = eficall! {unsafe fn(
     *mut Protocol,
     usize,
 ) -> crate::base::Status};
 
-pub type ProtocolClearScreen = eficall! {fn(
+pub type ProtocolClearScreen = eficall! {unsafe fn(
     *mut Protocol,
 ) -> crate::base::Status};
 
-pub type ProtocolSetCursorPosition = eficall! {fn(
+pub type ProtocolSetCursorPosition = eficall! {unsafe fn(
     *mut Protocol,
     usize,
     usize,
 ) -> crate::base::Status};
 
-pub type ProtocolEnableCursor = eficall! {fn(
+pub type ProtocolEnableCursor = eficall! {unsafe fn(
     *mut Protocol,
     crate::base::Boolean,
 ) -> crate::base::Status};

--- a/src/protocols/tcp4.rs
+++ b/src/protocols/tcp4.rs
@@ -153,7 +153,7 @@ pub struct CloseToken {
     pub abort_on_close: crate::base::Boolean,
 }
 
-pub type ProtocolGetModeData = eficall! {fn(
+pub type ProtocolGetModeData = eficall! {unsafe fn(
     *mut Protocol,
     *mut ConnectionState,
     *mut ConfigData,
@@ -162,12 +162,12 @@ pub type ProtocolGetModeData = eficall! {fn(
     *mut crate::protocols::simple_network::Mode,
 ) -> crate::base::Status};
 
-pub type ProtocolConfigure = eficall! {fn(
+pub type ProtocolConfigure = eficall! {unsafe fn(
     *mut Protocol,
     *mut ConfigData,
 ) -> crate::base::Status};
 
-pub type ProtocolRoutes = eficall! {fn(
+pub type ProtocolRoutes = eficall! {unsafe fn(
     *mut Protocol,
     crate::base::Boolean,
     *mut crate::base::Ipv4Address,
@@ -175,37 +175,37 @@ pub type ProtocolRoutes = eficall! {fn(
     *mut crate::base::Ipv4Address,
 ) -> crate::base::Status};
 
-pub type ProtocolConnect = eficall! {fn(
+pub type ProtocolConnect = eficall! {unsafe fn(
     *mut Protocol,
     *mut ConnectionToken,
 ) -> crate::base::Status};
 
-pub type ProtocolAccept = eficall! {fn(
+pub type ProtocolAccept = eficall! {unsafe fn(
     *mut Protocol,
     *mut ListenToken,
 ) -> crate::base::Status};
 
-pub type ProtocolTransmit = eficall! {fn(
+pub type ProtocolTransmit = eficall! {unsafe fn(
     *mut Protocol,
     *mut IoToken,
 ) -> crate::base::Status};
 
-pub type ProtocolReceive = eficall! {fn(
+pub type ProtocolReceive = eficall! {unsafe fn(
     *mut Protocol,
     *mut IoToken,
 ) -> crate::base::Status};
 
-pub type ProtocolClose = eficall! {fn(
+pub type ProtocolClose = eficall! {unsafe fn(
     *mut Protocol,
     *mut CloseToken,
 ) -> crate::base::Status};
 
-pub type ProtocolCancel = eficall! {fn(
+pub type ProtocolCancel = eficall! {unsafe fn(
     *mut Protocol,
     *mut CompletionToken,
 ) -> crate::base::Status};
 
-pub type ProtocolPoll = eficall! {fn(
+pub type ProtocolPoll = eficall! {unsafe fn(
     *mut Protocol,
 ) -> crate::base::Status};
 

--- a/src/protocols/tcp6.rs
+++ b/src/protocols/tcp6.rs
@@ -140,7 +140,7 @@ pub struct CloseToken {
     pub abort_on_close: crate::base::Boolean,
 }
 
-pub type ProtocolGetModeData = eficall! {fn(
+pub type ProtocolGetModeData = eficall! {unsafe fn(
     *mut Protocol,
     *mut ConnectionState,
     *mut ConfigData,
@@ -149,42 +149,42 @@ pub type ProtocolGetModeData = eficall! {fn(
     *mut crate::protocols::simple_network::Mode,
 ) -> crate::base::Status};
 
-pub type ProtocolConfigure = eficall! {fn(
+pub type ProtocolConfigure = eficall! {unsafe fn(
     *mut Protocol,
     *mut ConfigData,
 ) -> crate::base::Status};
 
-pub type ProtocolConnect = eficall! {fn(
+pub type ProtocolConnect = eficall! {unsafe fn(
     *mut Protocol,
     *mut ConnectionToken,
 ) -> crate::base::Status};
 
-pub type ProtocolAccept = eficall! {fn(
+pub type ProtocolAccept = eficall! {unsafe fn(
     *mut Protocol,
     *mut ListenToken,
 ) -> crate::base::Status};
 
-pub type ProtocolTransmit = eficall! {fn(
+pub type ProtocolTransmit = eficall! {unsafe fn(
     *mut Protocol,
     *mut IoToken,
 ) -> crate::base::Status};
 
-pub type ProtocolReceive = eficall! {fn(
+pub type ProtocolReceive = eficall! {unsafe fn(
     *mut Protocol,
     *mut IoToken,
 ) -> crate::base::Status};
 
-pub type ProtocolClose = eficall! {fn(
+pub type ProtocolClose = eficall! {unsafe fn(
     *mut Protocol,
     *mut CloseToken,
 ) -> crate::base::Status};
 
-pub type ProtocolCancel = eficall! {fn(
+pub type ProtocolCancel = eficall! {unsafe fn(
     *mut Protocol,
     *mut CompletionToken,
 ) -> crate::base::Status};
 
-pub type ProtocolPoll = eficall! {fn(
+pub type ProtocolPoll = eficall! {unsafe fn(
     *mut Protocol,
 ) -> crate::base::Status};
 

--- a/src/protocols/timestamp.rs
+++ b/src/protocols/timestamp.rs
@@ -21,7 +21,7 @@ pub struct Properties {
 
 pub type ProtocolGetTimestamp = eficall! {fn() -> u64};
 
-pub type ProtocolGetProperties = eficall! {fn(
+pub type ProtocolGetProperties = eficall! {unsafe fn(
     *mut Properties,
 ) -> crate::base::Status};
 

--- a/src/protocols/udp4.rs
+++ b/src/protocols/udp4.rs
@@ -92,7 +92,7 @@ pub struct CompletionToken {
     pub packet: CompletionTokenPacket,
 }
 
-pub type ProtocolGetModeData = eficall! {fn(
+pub type ProtocolGetModeData = eficall! {unsafe fn(
     *mut Protocol,
     *mut ConfigData,
     *mut crate::protocols::ip4::ModeData,
@@ -100,18 +100,18 @@ pub type ProtocolGetModeData = eficall! {fn(
     *mut crate::protocols::simple_network::Mode,
 ) -> crate::base::Status};
 
-pub type ProtocolConfigure = eficall! {fn(
+pub type ProtocolConfigure = eficall! {unsafe fn(
     *mut Protocol,
     *mut ConfigData,
 ) -> crate::base::Status};
 
-pub type ProtocolGroups = eficall! {fn(
+pub type ProtocolGroups = eficall! {unsafe fn(
     *mut Protocol,
     crate::base::Boolean,
     *mut crate::base::Ipv4Address,
 ) -> crate::base::Status};
 
-pub type ProtocolRoutes = eficall! {fn(
+pub type ProtocolRoutes = eficall! {unsafe fn(
     *mut Protocol,
     crate::base::Boolean,
     *mut crate::base::Ipv4Address,
@@ -119,22 +119,22 @@ pub type ProtocolRoutes = eficall! {fn(
     *mut crate::base::Ipv4Address,
 ) -> crate::base::Status};
 
-pub type ProtocolTransmit = eficall! {fn(
+pub type ProtocolTransmit = eficall! {unsafe fn(
     *mut Protocol,
     *mut CompletionToken,
 ) -> crate::base::Status};
 
-pub type ProtocolReceive = eficall! {fn(
+pub type ProtocolReceive = eficall! {unsafe fn(
     *mut Protocol,
     *mut CompletionToken,
 ) -> crate::base::Status};
 
-pub type ProtocolCancel = eficall! {fn(
+pub type ProtocolCancel = eficall! {unsafe fn(
     *mut Protocol,
     *mut CompletionToken,
 ) -> crate::base::Status};
 
-pub type ProtocolPoll = eficall! {fn(
+pub type ProtocolPoll = eficall! {unsafe fn(
     *mut Protocol,
 ) -> crate::base::Status};
 

--- a/src/protocols/udp6.rs
+++ b/src/protocols/udp6.rs
@@ -87,7 +87,7 @@ pub struct CompletionToken {
     pub packet: CompletionTokenPacket,
 }
 
-pub type ProtocolGetModeData = eficall! {fn(
+pub type ProtocolGetModeData = eficall! {unsafe fn(
     *mut Protocol,
     *mut ConfigData,
     *mut crate::protocols::ip6::ModeData,
@@ -95,33 +95,33 @@ pub type ProtocolGetModeData = eficall! {fn(
     *mut crate::protocols::simple_network::Mode,
 ) -> crate::base::Status};
 
-pub type ProtocolConfigure = eficall! {fn(
+pub type ProtocolConfigure = eficall! {unsafe fn(
     *mut Protocol,
     *mut ConfigData,
 ) -> crate::base::Status};
 
-pub type ProtocolGroups = eficall! {fn(
+pub type ProtocolGroups = eficall! {unsafe fn(
     *mut Protocol,
     crate::base::Boolean,
     *mut crate::base::Ipv6Address,
 ) -> crate::base::Status};
 
-pub type ProtocolTransmit = eficall! {fn(
+pub type ProtocolTransmit = eficall! {unsafe fn(
     *mut Protocol,
     *mut CompletionToken,
 ) -> crate::base::Status};
 
-pub type ProtocolReceive = eficall! {fn(
+pub type ProtocolReceive = eficall! {unsafe fn(
     *mut Protocol,
     *mut CompletionToken,
 ) -> crate::base::Status};
 
-pub type ProtocolCancel = eficall! {fn(
+pub type ProtocolCancel = eficall! {unsafe fn(
     *mut Protocol,
     *mut CompletionToken,
 ) -> crate::base::Status};
 
-pub type ProtocolPoll = eficall! {fn(
+pub type ProtocolPoll = eficall! {unsafe fn(
     *mut Protocol,
 ) -> crate::base::Status};
 

--- a/src/system.rs
+++ b/src/system.rs
@@ -230,7 +230,7 @@ pub const EVT_NOTIFY_SIGNAL: u32 = 0x00000200u32;
 pub const EVT_SIGNAL_EXIT_BOOT_SERVICES: u32 = 0x00000201u32;
 pub const EVT_SIGNAL_VIRTUAL_ADDRESS_CHANGE: u32 = 0x60000202u32;
 
-pub type EventNotify = eficall! {fn(crate::base::Event, *mut core::ffi::c_void)};
+pub type EventNotify = eficall! {unsafe fn(crate::base::Event, *mut core::ffi::c_void)};
 
 pub const EVENT_GROUP_EXIT_BOOT_SERVICES: crate::base::Guid = crate::base::Guid::from_fields(
     0x27abf055,
@@ -654,39 +654,39 @@ pub struct TableHeader {
 pub const RUNTIME_SERVICES_SIGNATURE: u64 = 0x56524553544e5552u64; // "RUNTSERV"
 pub const RUNTIME_SERVICES_REVISION: u32 = SPECIFICATION_REVISION;
 
-pub type RuntimeGetTime = eficall! {fn(
+pub type RuntimeGetTime = eficall! {unsafe fn(
     *mut Time,
     *mut TimeCapabilities,
 ) -> crate::base::Status};
 
-pub type RuntimeSetTime = eficall! {fn(
+pub type RuntimeSetTime = eficall! {unsafe fn(
     *mut Time,
 ) -> crate::base::Status};
 
-pub type RuntimeGetWakeupTime = eficall! {fn(
+pub type RuntimeGetWakeupTime = eficall! {unsafe fn(
     *mut crate::base::Boolean,
     *mut crate::base::Boolean,
     *mut Time,
 ) -> crate::base::Status};
 
-pub type RuntimeSetWakeupTime = eficall! {fn(
+pub type RuntimeSetWakeupTime = eficall! {unsafe fn(
     crate::base::Boolean,
     *mut Time,
 ) -> crate::base::Status};
 
-pub type RuntimeSetVirtualAddressMap = eficall! {fn(
+pub type RuntimeSetVirtualAddressMap = eficall! {unsafe fn(
     usize,
     usize,
     u32,
     *mut MemoryDescriptor,
 ) -> crate::base::Status};
 
-pub type RuntimeConvertPointer = eficall! {fn(
+pub type RuntimeConvertPointer = eficall! {unsafe fn(
     usize,
     *mut *mut core::ffi::c_void,
 ) -> crate::base::Status};
 
-pub type RuntimeGetVariable = eficall! {fn(
+pub type RuntimeGetVariable = eficall! {unsafe fn(
     *mut crate::base::Char16,
     *mut crate::base::Guid,
     *mut u32,
@@ -694,13 +694,13 @@ pub type RuntimeGetVariable = eficall! {fn(
     *mut core::ffi::c_void,
 ) -> crate::base::Status};
 
-pub type RuntimeGetNextVariableName = eficall! {fn(
+pub type RuntimeGetNextVariableName = eficall! {unsafe fn(
     *mut usize,
     *mut crate::base::Char16,
     *mut crate::base::Guid,
 ) -> crate::base::Status};
 
-pub type RuntimeSetVariable = eficall! {fn(
+pub type RuntimeSetVariable = eficall! {unsafe fn(
     *mut crate::base::Char16,
     *mut crate::base::Guid,
     u32,
@@ -708,31 +708,31 @@ pub type RuntimeSetVariable = eficall! {fn(
     *mut core::ffi::c_void,
 ) -> crate::base::Status};
 
-pub type RuntimeGetNextHighMonoCount = eficall! {fn(
+pub type RuntimeGetNextHighMonoCount = eficall! {unsafe fn(
     *mut u32,
 ) -> crate::base::Status};
 
-pub type RuntimeResetSystem = eficall! {fn(
+pub type RuntimeResetSystem = eficall! {unsafe fn(
     ResetType,
     crate::base::Status,
     usize,
     *mut core::ffi::c_void,
 )};
 
-pub type RuntimeUpdateCapsule = eficall! {fn(
+pub type RuntimeUpdateCapsule = eficall! {unsafe fn(
     *mut *mut CapsuleHeader,
     usize,
     crate::base::PhysicalAddress,
 ) -> crate::base::Status};
 
-pub type RuntimeQueryCapsuleCapabilities = eficall! {fn(
+pub type RuntimeQueryCapsuleCapabilities = eficall! {unsafe fn(
     *mut *mut CapsuleHeader,
     usize,
     *mut u64,
     *mut ResetType,
 ) -> crate::base::Status};
 
-pub type RuntimeQueryVariableInfo = eficall! {fn(
+pub type RuntimeQueryVariableInfo = eficall! {unsafe fn(
     u32,
     *mut u64,
     *mut u64,
@@ -774,19 +774,19 @@ pub type BootRestoreTpl = eficall! {fn(
     crate::base::Tpl,
 )};
 
-pub type BootAllocatePages = eficall! {fn(
+pub type BootAllocatePages = eficall! {unsafe fn(
     AllocateType,
     MemoryType,
     usize,
     *mut crate::base::PhysicalAddress,
 ) -> crate::base::Status};
 
-pub type BootFreePages = eficall! {fn(
+pub type BootFreePages = eficall! {unsafe fn(
     crate::base::PhysicalAddress,
     usize,
 ) -> crate::base::Status};
 
-pub type BootGetMemoryMap = eficall! {fn(
+pub type BootGetMemoryMap = eficall! {unsafe fn(
     *mut usize,
     *mut MemoryDescriptor,
     *mut usize,
@@ -794,17 +794,17 @@ pub type BootGetMemoryMap = eficall! {fn(
     *mut u32,
 ) -> crate::base::Status};
 
-pub type BootAllocatePool = eficall! {fn(
+pub type BootAllocatePool = eficall! {unsafe fn(
     MemoryType,
     usize,
     *mut *mut core::ffi::c_void,
 ) -> crate::base::Status};
 
-pub type BootFreePool = eficall! {fn(
+pub type BootFreePool = eficall! {unsafe fn(
     *mut core::ffi::c_void,
 ) -> crate::base::Status};
 
-pub type BootCreateEvent = eficall! {fn(
+pub type BootCreateEvent = eficall! {unsafe fn(
     u32,
     crate::base::Tpl,
     Option<EventNotify>,
@@ -812,63 +812,63 @@ pub type BootCreateEvent = eficall! {fn(
     *mut crate::base::Event,
 ) -> crate::base::Status};
 
-pub type BootSetTimer = eficall! {fn(
+pub type BootSetTimer = eficall! {unsafe fn(
     crate::base::Event,
     TimerDelay,
     u64,
 ) -> crate::base::Status};
 
-pub type BootWaitForEvent = eficall! {fn(
+pub type BootWaitForEvent = eficall! {unsafe fn(
     usize,
     *mut crate::base::Event,
     *mut usize,
 ) -> crate::base::Status};
 
-pub type BootSignalEvent = eficall! {fn(
+pub type BootSignalEvent = eficall! {unsafe fn(
     crate::base::Event,
 ) -> crate::base::Status};
 
-pub type BootCloseEvent = eficall! {fn(
+pub type BootCloseEvent = eficall! {unsafe fn(
     crate::base::Event,
 ) -> crate::base::Status};
 
-pub type BootCheckEvent = eficall! {fn(
+pub type BootCheckEvent = eficall! {unsafe fn(
     crate::base::Event,
 ) -> crate::base::Status};
 
-pub type BootInstallProtocolInterface = eficall! {fn(
+pub type BootInstallProtocolInterface = eficall! {unsafe fn(
     *mut crate::base::Handle,
     *mut crate::base::Guid,
     InterfaceType,
     *mut core::ffi::c_void,
 ) -> crate::base::Status};
 
-pub type BootReinstallProtocolInterface = eficall! {fn(
+pub type BootReinstallProtocolInterface = eficall! {unsafe fn(
     crate::base::Handle,
     *mut crate::base::Guid,
     *mut core::ffi::c_void,
     *mut core::ffi::c_void,
 ) -> crate::base::Status};
 
-pub type BootUninstallProtocolInterface = eficall! {fn(
+pub type BootUninstallProtocolInterface = eficall! {unsafe fn(
     crate::base::Handle,
     *mut crate::base::Guid,
     *mut core::ffi::c_void,
 ) -> crate::base::Status};
 
-pub type BootHandleProtocol = eficall! {fn(
+pub type BootHandleProtocol = eficall! {unsafe fn(
     crate::base::Handle,
     *mut crate::base::Guid,
     *mut *mut core::ffi::c_void,
 ) -> crate::base::Status};
 
-pub type BootRegisterProtocolNotify = eficall! {fn(
+pub type BootRegisterProtocolNotify = eficall! {unsafe fn(
     *mut crate::base::Guid,
     crate::base::Event,
     *mut *mut core::ffi::c_void,
 ) -> crate::base::Status};
 
-pub type BootLocateHandle = eficall! {fn(
+pub type BootLocateHandle = eficall! {unsafe fn(
     LocateSearchType,
     *mut crate::base::Guid,
     *mut core::ffi::c_void,
@@ -876,18 +876,18 @@ pub type BootLocateHandle = eficall! {fn(
     *mut crate::base::Handle,
 ) -> crate::base::Status};
 
-pub type BootLocateDevicePath = eficall! {fn(
+pub type BootLocateDevicePath = eficall! {unsafe fn(
     *mut crate::base::Guid,
     *mut *mut crate::protocols::device_path::Protocol,
     *mut crate::base::Handle,
 ) -> crate::base::Status};
 
-pub type BootInstallConfigurationTable = eficall! {fn(
+pub type BootInstallConfigurationTable = eficall! {unsafe fn(
     *mut crate::base::Guid,
     *mut core::ffi::c_void,
 ) -> crate::base::Status};
 
-pub type BootLoadImage = eficall! {fn(
+pub type BootLoadImage = eficall! {unsafe fn(
     crate::base::Boolean,
     crate::base::Handle,
     *mut crate::protocols::device_path::Protocol,
@@ -896,29 +896,29 @@ pub type BootLoadImage = eficall! {fn(
     *mut crate::base::Handle,
 ) -> crate::base::Status};
 
-pub type BootStartImage = eficall! {fn(
+pub type BootStartImage = eficall! {unsafe fn(
     crate::base::Handle,
     *mut usize,
     *mut *mut crate::base::Char16,
 ) -> crate::base::Status};
 
-pub type BootExit = eficall! {fn(
+pub type BootExit = eficall! {unsafe fn(
     crate::base::Handle,
     crate::base::Status,
     usize,
     *mut crate::base::Char16,
 ) -> crate::base::Status};
 
-pub type BootUnloadImage = eficall! {fn(
+pub type BootUnloadImage = eficall! {unsafe fn(
     crate::base::Handle,
 ) -> crate::base::Status};
 
-pub type BootExitBootServices = eficall! {fn(
+pub type BootExitBootServices = eficall! {unsafe fn(
     crate::base::Handle,
     usize,
 ) -> crate::base::Status};
 
-pub type BootGetNextMonotonicCount = eficall! {fn(
+pub type BootGetNextMonotonicCount = eficall! {unsafe fn(
     *mut u64,
 ) -> crate::base::Status};
 
@@ -926,27 +926,27 @@ pub type BootStall = eficall! {fn(
     usize,
 ) -> crate::base::Status};
 
-pub type BootSetWatchdogTimer = eficall! {fn(
+pub type BootSetWatchdogTimer = eficall! {unsafe fn(
     usize,
     u64,
     usize,
     *mut crate::base::Char16,
 ) -> crate::base::Status};
 
-pub type BootConnectController = eficall! {fn(
+pub type BootConnectController = eficall! {unsafe fn(
     crate::base::Handle,
     *mut crate::base::Handle,
     *mut crate::protocols::device_path::Protocol,
     crate::base::Boolean,
 ) -> crate::base::Status};
 
-pub type BootDisconnectController = eficall! {fn(
+pub type BootDisconnectController = eficall! {unsafe fn(
     crate::base::Handle,
     crate::base::Handle,
     crate::base::Handle,
 ) -> crate::base::Status};
 
-pub type BootOpenProtocol = eficall! {fn(
+pub type BootOpenProtocol = eficall! {unsafe fn(
     crate::base::Handle,
     *mut crate::base::Guid,
     *mut *mut core::ffi::c_void,
@@ -955,27 +955,27 @@ pub type BootOpenProtocol = eficall! {fn(
     u32,
 ) -> crate::base::Status};
 
-pub type BootCloseProtocol = eficall! {fn(
+pub type BootCloseProtocol = eficall! {unsafe fn(
     crate::base::Handle,
     *mut crate::base::Guid,
     crate::base::Handle,
     crate::base::Handle,
 ) -> crate::base::Status};
 
-pub type BootOpenProtocolInformation = eficall! {fn(
+pub type BootOpenProtocolInformation = eficall! {unsafe fn(
     crate::base::Handle,
     *mut crate::base::Guid,
     *mut *mut OpenProtocolInformationEntry,
     *mut usize,
 ) -> crate::base::Status};
 
-pub type BootProtocolsPerHandle = eficall! {fn(
+pub type BootProtocolsPerHandle = eficall! {unsafe fn(
     crate::base::Handle,
     *mut *mut *mut crate::base::Guid,
     *mut usize,
 ) -> crate::base::Status};
 
-pub type BootLocateHandleBuffer = eficall! {fn(
+pub type BootLocateHandleBuffer = eficall! {unsafe fn(
     LocateSearchType,
     *mut crate::base::Guid,
     *mut core::ffi::c_void,
@@ -983,45 +983,45 @@ pub type BootLocateHandleBuffer = eficall! {fn(
     *mut *mut crate::base::Handle,
 ) -> crate::base::Status};
 
-pub type BootLocateProtocol = eficall! {fn(
+pub type BootLocateProtocol = eficall! {unsafe fn(
     *mut crate::base::Guid,
     *mut core::ffi::c_void,
     *mut *mut core::ffi::c_void,
 ) -> crate::base::Status};
 
-pub type BootInstallMultipleProtocolInterfaces = eficall! {fn(
+pub type BootInstallMultipleProtocolInterfaces = eficall! {unsafe fn(
     *mut crate::base::Handle,
     // XXX: Actual definition is variadic. See eficall!{} for details.
     *mut core::ffi::c_void,
     *mut core::ffi::c_void,
 ) -> crate::base::Status};
 
-pub type BootUninstallMultipleProtocolInterfaces = eficall! {fn(
+pub type BootUninstallMultipleProtocolInterfaces = eficall! {unsafe fn(
     crate::base::Handle,
     // XXX: Actual definition is variadic. See eficall!{} for details.
     *mut core::ffi::c_void,
     *mut core::ffi::c_void,
 ) -> crate::base::Status};
 
-pub type BootCalculateCrc32 = eficall! {fn(
+pub type BootCalculateCrc32 = eficall! {unsafe fn(
     *mut core::ffi::c_void,
     usize,
     *mut u32,
 ) -> crate::base::Status};
 
-pub type BootCopyMem = eficall! {fn(
+pub type BootCopyMem = eficall! {unsafe fn(
     *mut core::ffi::c_void,
     *mut core::ffi::c_void,
     usize,
 )};
 
-pub type BootSetMem = eficall! {fn(
+pub type BootSetMem = eficall! {unsafe fn(
     *mut core::ffi::c_void,
     usize,
     u8,
 )};
 
-pub type BootCreateEventEx = eficall! {fn(
+pub type BootCreateEventEx = eficall! {unsafe fn(
     u32,
     crate::base::Tpl,
     Option<EventNotify>,

--- a/src/vendor/intel/console_control.rs
+++ b/src/vendor/intel/console_control.rs
@@ -20,17 +20,17 @@ pub const SCREEN_MAX_VALUE: ScreenMode = 0x00000002;
 
 #[repr(C)]
 pub struct Protocol {
-    pub get_mode: eficall! {fn(
+    pub get_mode: eficall! {unsafe fn(
         *mut Protocol,
         *mut ScreenMode,
         *mut crate::base::Boolean,
         *mut crate::base::Boolean,
     ) -> crate::base::Status},
-    pub set_mode: eficall! {fn(
+    pub set_mode: eficall! {unsafe fn(
         *mut Protocol,
         ScreenMode,
     ) -> crate::base::Status},
-    pub lock_std_in: eficall! {fn(
+    pub lock_std_in: eficall! {unsafe fn(
         *mut Protocol,
         *mut crate::base::Char16,
     ) -> crate::base::Status},


### PR DESCRIPTION
Surely it's only safe to call the vast majority of EFI functions if the caller upholds certain requirements: for example, most EFI functions have one or more parameters of pointer type—and it's surely UB if those pointers aren't valid?