### PR TITLE
Add Partition Info Protocol definitions

### DIFF
--- a/src/protocols.rs
+++ b/src/protocols.rs
@@ -35,6 +35,7 @@ pub mod loaded_image_device_path;
 pub mod managed_network;
 pub mod memory_attribute;
 pub mod mp_services;
+pub mod partition_info;
 pub mod pci_io;
 pub mod platform_driver_override;
 pub mod rng;

--- a/src/protocols/partition_info.rs
+++ b/src/protocols/partition_info.rs
@@ -1,0 +1,30 @@
+//! Partition Info Protocol
+//!
+//! The Partition Info protocol provides access to partition information.
+
+use crate::efi::Guid;
+
+pub const PROTOCOL_GUID: Guid = Guid::from_fields(
+    0x8cf2f62c,
+    0xbc9b,
+    0x4821,
+    0x80,
+    0x8d,
+    &[0xec, 0x9e, 0xc4, 0x21, 0xa1, 0xa0],
+);
+
+pub const REVISION: u32 = 0x00010000;
+
+pub const TYPE_OTHER: u32 = 0x00;
+pub const TYPE_MBR: u32 = 0x01;
+pub const TYPE_GPT: u32 = 0x02;
+
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct Protocol {
+    pub revision: u32,
+    pub partition_type: u32,
+    pub system: u8,
+    pub reserved: [u8; 7],
+    pub info: [u8; 128],
+}


### PR DESCRIPTION
Include the Partition Info Protocol definitions, including the protocol GUID, revision constant, partition type constants, and the protocol structure itself. This protocol provides access to information about a partition.