### PR TITLE
Make use of variadics in function declarations

### DIFF
--- a/.github/workflows/rust-tests.yml
+++ b/.github/workflows/rust-tests.yml
@@ -48,6 +48,33 @@ jobs:
       run: cargo test --verbose
 
   #
+  # CI with explicit MSRV feature
+  #
+  # This simply runs `cargo build && cargo test` on all sources, but selects
+  # different MSRVs via feature flags.
+  #
+  ci-feature-msrv:
+    name: "Default (feature: msrv) - rust-${{ matrix.rust }}@${{ matrix.os }}"
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ["ubuntu-latest"]
+        rust: ["stable"]
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+    - name: "Fetch Sources"
+      uses: actions/checkout@v3
+    - name: "Install Rust Components"
+      run: rustup default "${{ matrix.rust }}"
+    - name: "Build Project"
+      run: cargo build --features msrv-1-91 --verbose --all-targets
+    - name: "Run Tests"
+      run: cargo test --features msrv-1-91 --verbose
+
+  #
   # Cross-Compilation to UEFI Target
   #
   # This cross-compiles all sources (including the examples) for native UEFI

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,8 @@ rust-version = "1.68"
 core = { version = '1.0.0', optional = true, package = 'rustc-std-workspace-core' }
 
 [features]
+# Enable features requiring rustc-1.91 or newer.
+msrv-1-91 = []
 # We feature-gate all native code, since it will not link correctly, unless you
 # use a UEFI target configuration. To make `cargo test` work, we exclude all
 # these from normal runs.

--- a/src/system.rs
+++ b/src/system.rs
@@ -1064,16 +1064,28 @@ pub type BootLocateProtocol = unsafe extern "efiapi" fn(
     *mut *mut core::ffi::c_void,
 ) -> crate::base::Status;
 
+#[cfg(feature = "msrv-1-91")]
 pub type BootInstallMultipleProtocolInterfaces = unsafe extern "efiapi" fn(
     *mut crate::base::Handle,
-    // XXX: Actual definition is variadic. See eficall!{} for details.
+    ...,
+) -> crate::base::Status;
+
+#[cfg(not(feature = "msrv-1-91"))]
+pub type BootInstallMultipleProtocolInterfaces = unsafe extern "efiapi" fn(
+    *mut crate::base::Handle,
     *mut core::ffi::c_void,
     *mut core::ffi::c_void,
 ) -> crate::base::Status;
 
+#[cfg(feature = "msrv-1-91")]
 pub type BootUninstallMultipleProtocolInterfaces = unsafe extern "efiapi" fn(
     crate::base::Handle,
-    // XXX: Actual definition is variadic. See eficall!{} for details.
+    ...,
+) -> crate::base::Status;
+
+#[cfg(not(feature = "msrv-1-91"))]
+pub type BootUninstallMultipleProtocolInterfaces = unsafe extern "efiapi" fn(
+    crate::base::Handle,
     *mut core::ffi::c_void,
     *mut core::ffi::c_void,
 ) -> crate::base::Status;


### PR DESCRIPTION
Adjust the boot-services that use variadics to actually use `...` in Rust. Rust has always supported variadics with `extern "C"` prototypes, but only gained support for variadics in other calling-conventions with 1.91.

Note that _implementing_ variadic functions still requires assembly or C (unstable support in Rust via `c_variadics`).

This PR takes #87 from @Ayush1325 but adds an `msrv-1-91` feature flag to avoid bumping the MSRV. Note that rust-version guards are unstable, so the feature flag is a simple way out.

Given that feature flags are additive and merged across a dependency tree, this is a breaking change (e.g., a crate does not set the flag, but one of its dependencies does, and thus the API for the original crate changes). We will likely delay this PR until the next release with a major version bump.