### PR TITLE
Add EFI_USB_IO_PROTOCOL per section 7.2 of UEFI Spec v2.11

### DIFF
--- a/src/industry.rs
+++ b/src/industry.rs
@@ -1,0 +1,6 @@
+//! Industry Standard Definitions
+//!
+//! This module contains definitions from industry standards used by UEFI
+//! protocols.
+
+pub mod usb;

--- a/src/industry/usb.rs
+++ b/src/industry/usb.rs
@@ -1,0 +1,94 @@
+//! Universal Serial Bus Definitions
+
+#[derive(Clone, Copy, Debug)]
+#[repr(C, packed(1))]
+pub struct DeviceRequest {
+    pub request_type: u8,
+    pub request: u8,
+    pub value: u16,
+    pub index: u16,
+    pub length: u16,
+}
+
+#[derive(Clone, Copy, Debug)]
+#[repr(C, packed(1))]
+pub struct DeviceDescriptor {
+    pub length: u8,
+    pub descriptor_type: u8,
+    pub bcd_usb: u16,
+    pub device_class: u8,
+    pub device_sub_class: u8,
+    pub device_protocol: u8,
+    pub max_packet_size0: u8,
+    pub id_vendor: u16,
+    pub id_product: u16,
+    pub bcd_device: u16,
+    pub str_manufacturer: u8,
+    pub str_product: u8,
+    pub str_serial_number: u8,
+    pub num_configurations: u8,
+}
+
+#[derive(Clone, Copy, Debug)]
+#[repr(C, packed(1))]
+pub struct ConfigDescriptor {
+    pub length: u8,
+    pub descriptor_type: u8,
+    pub total_length: u16,
+    pub num_interfaces: u8,
+    pub configuration_value: u8,
+    pub configuration: u8,
+    pub attributes: u8,
+    pub max_power: u8,
+}
+
+#[derive(Clone, Copy, Debug)]
+#[repr(C, packed(1))]
+pub struct InterfaceDescriptor {
+    pub length: u8,
+    pub descriptor_type: u8,
+    pub interface_number: u8,
+    pub alternate_setting: u8,
+    pub num_endpoints: u8,
+    pub interface_class: u8,
+    pub interface_sub_class: u8,
+    pub interface_protocol: u8,
+    pub interface: u8,
+}
+
+#[derive(Clone, Copy, Debug)]
+#[repr(C, packed(1))]
+pub struct EndpointDescriptor {
+    pub length: u8,
+    pub descriptor_type: u8,
+    pub endpoint_address: u8,
+    pub attributes: u8,
+    pub max_packet_size: u16,
+    pub interval: u8,
+}
+
+#[cfg(test)]
+mod test {
+    use core::mem;
+    use super::*;
+
+    // USB device requests and descriptors are standard USB wire-format
+    // structures, so verify that the layouts are byte-packed.
+    #[test]
+    fn layout() {
+        assert_eq!(mem::align_of::<DeviceRequest>(), 1);
+        assert_eq!(mem::size_of::<DeviceRequest>(), 8);
+
+        assert_eq!(mem::align_of::<DeviceDescriptor>(), 1);
+        assert_eq!(mem::size_of::<DeviceDescriptor>(), 18);
+
+        assert_eq!(mem::align_of::<ConfigDescriptor>(), 1);
+        assert_eq!(mem::size_of::<ConfigDescriptor>(), 9);
+
+        assert_eq!(mem::align_of::<InterfaceDescriptor>(), 1);
+        assert_eq!(mem::size_of::<InterfaceDescriptor>(), 9);
+
+        assert_eq!(mem::align_of::<EndpointDescriptor>(), 1);
+        assert_eq!(mem::size_of::<EndpointDescriptor>(), 7);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -212,6 +212,10 @@ pub mod hii;
 #[rustfmt::skip]
 pub mod system;
 
+// Import definitions from industry standards that are used by UEFI protocols.
+#[rustfmt::skip]
+pub mod industry;
+
 // Import the protocols. Each protocol is separated into its own module, readily imported by the
 // meta `protocols` module. Note that this puts all symbols into their respective protocol
 // namespace, thus clearly separating them (unlike the UEFI Specification, which more often than
@@ -241,6 +245,7 @@ pub mod efi {
 
     pub use crate::gpt;
     pub use crate::hii;
+    pub use crate::industry;
     pub use crate::protocols;
     pub use crate::vendor;
 }

--- a/src/protocols.rs
+++ b/src/protocols.rs
@@ -53,3 +53,4 @@ pub mod tcp6;
 pub mod timestamp;
 pub mod udp4;
 pub mod udp6;
+pub mod usb_io;

--- a/src/protocols/usb_io.rs
+++ b/src/protocols/usb_io.rs
@@ -1,0 +1,148 @@
+//! USB I/O Protocol
+//!
+//! Provides services to manage and communicate with USB devices. This protocol is used by code,
+//! typically drivers, running in the EFI boot services environment to access USB devices like
+//! USB keyboards, mice, and mass storage devices.
+
+pub const PROTOCOL_GUID: crate::base::Guid = crate::base::Guid::from_fields(
+    0x2b2f68d6,
+    0x0cd2,
+    0x44cf,
+    0x8e,
+    0x8b,
+    &[0xbb, 0xa2, 0x0b, 0x1b, 0x5b, 0x75],
+);
+
+pub type DataDirection = u32;
+
+pub const DATA_IN: DataDirection = 0x00000000;
+pub const DATA_OUT: DataDirection = 0x00000001;
+pub const NO_DATA: DataDirection = 0x00000002;
+
+pub const NOERROR: u32 = 0x0000;
+pub const ERR_NOTEXECUTE: u32 = 0x0001;
+pub const ERR_STALL: u32 = 0x0002;
+pub const ERR_BUFFER: u32 = 0x0004;
+pub const ERR_BABBLE: u32 = 0x0008;
+pub const ERR_NAK: u32 = 0x0010;
+pub const ERR_CRC: u32 = 0x0020;
+pub const ERR_TIMEOUT: u32 = 0x0040;
+pub const ERR_BITSTUFF: u32 = 0x0080;
+pub const ERR_SYSTEM: u32 = 0x0100;
+
+pub type AsyncUsbTransferCallback = unsafe extern "efiapi" fn(
+    *mut core::ffi::c_void,
+    usize,
+    *mut core::ffi::c_void,
+    u32,
+) -> crate::base::Status;
+
+pub type ProtocolControlTransfer = unsafe extern "efiapi" fn(
+    *mut Protocol,
+    *mut crate::industry::usb::DeviceRequest,
+    DataDirection,
+    u32,
+    *mut core::ffi::c_void,
+    usize,
+    *mut u32,
+) -> crate::base::Status;
+
+pub type ProtocolBulkTransfer = unsafe extern "efiapi" fn(
+    *mut Protocol,
+    u8,
+    *mut core::ffi::c_void,
+    *mut usize,
+    usize,
+    *mut u32,
+) -> crate::base::Status;
+
+pub type ProtocolAsyncInterruptTransfer = unsafe extern "efiapi" fn(
+    *mut Protocol,
+    u8,
+    crate::base::Boolean,
+    usize,
+    usize,
+    Option<AsyncUsbTransferCallback>,
+    *mut core::ffi::c_void,
+) -> crate::base::Status;
+
+pub type ProtocolSyncInterruptTransfer = unsafe extern "efiapi" fn(
+    *mut Protocol,
+    u8,
+    *mut core::ffi::c_void,
+    *mut usize,
+    usize,
+    *mut u32,
+) -> crate::base::Status;
+
+pub type ProtocolIsochronousTransfer = unsafe extern "efiapi" fn(
+    *mut Protocol,
+    u8,
+    *mut core::ffi::c_void,
+    usize,
+    *mut u32,
+) -> crate::base::Status;
+
+pub type ProtocolAsyncIsochronousTransfer = unsafe extern "efiapi" fn(
+    *mut Protocol,
+    u8,
+    *mut core::ffi::c_void,
+    usize,
+    AsyncUsbTransferCallback,
+    *mut core::ffi::c_void,
+) -> crate::base::Status;
+
+pub type ProtocolGetDeviceDescriptor = unsafe extern "efiapi" fn(
+    *mut Protocol,
+    *mut crate::industry::usb::DeviceDescriptor,
+) -> crate::base::Status;
+
+pub type ProtocolGetConfigDescriptor = unsafe extern "efiapi" fn(
+    *mut Protocol,
+    *mut crate::industry::usb::ConfigDescriptor,
+) -> crate::base::Status;
+
+pub type ProtocolGetInterfaceDescriptor = unsafe extern "efiapi" fn(
+    *mut Protocol,
+    *mut crate::industry::usb::InterfaceDescriptor,
+) -> crate::base::Status;
+
+pub type ProtocolGetEndpointDescriptor = unsafe extern "efiapi" fn(
+    *mut Protocol,
+    u8,
+    *mut crate::industry::usb::EndpointDescriptor,
+) -> crate::base::Status;
+
+pub type ProtocolGetStringDescriptor = unsafe extern "efiapi" fn(
+    *mut Protocol,
+    u16,
+    u8,
+    *mut *mut crate::base::Char16,
+) -> crate::base::Status;
+
+pub type ProtocolGetSupportedLanguages = unsafe extern "efiapi" fn(
+    *mut Protocol,
+    *mut *mut u16,
+    *mut u16,
+) -> crate::base::Status;
+
+pub type ProtocolPortReset = unsafe extern "efiapi" fn(
+    *mut Protocol,
+) -> crate::base::Status;
+
+#[repr(C)]
+pub struct Protocol {
+    pub control_transfer: ProtocolControlTransfer,
+    pub bulk_transfer: ProtocolBulkTransfer,
+    pub async_interrupt_transfer: ProtocolAsyncInterruptTransfer,
+    pub sync_interrupt_transfer: ProtocolSyncInterruptTransfer,
+    pub isochronous_transfer: ProtocolIsochronousTransfer,
+    pub async_isochronous_transfer: ProtocolAsyncIsochronousTransfer,
+    pub get_device_descriptor: ProtocolGetDeviceDescriptor,
+    pub get_config_descriptor: ProtocolGetConfigDescriptor,
+    pub get_interface_descriptor: ProtocolGetInterfaceDescriptor,
+    pub get_endpoint_descriptor: ProtocolGetEndpointDescriptor,
+    pub get_string_descriptor: ProtocolGetStringDescriptor,
+    pub get_supported_languages: ProtocolGetSupportedLanguages,
+    pub port_reset: ProtocolPortReset,
+}


### PR DESCRIPTION
Adds definition of EFI_USB_IO_PROTOCOL.