### PR TITLE
protocols: add SMBIOS constants

### DIFF
--- a/src/protocols.rs
+++ b/src/protocols.rs
@@ -48,6 +48,7 @@ pub mod simple_network;
 pub mod simple_text_input;
 pub mod simple_text_input_ex;
 pub mod simple_text_output;
+pub mod smbios;
 pub mod tcp4;
 pub mod tcp6;
 pub mod timestamp;

--- a/src/protocols/smbios.rs
+++ b/src/protocols/smbios.rs
@@ -14,6 +14,3 @@ pub const PROTOCOL_GUID: crate::base::Guid = crate::base::Guid::from_fields(
 
 /// The reserved SMBIOS handle used for automatic handle assignment.
 pub const HANDLE_PI_RESERVED: u16 = 0xfffe;
-
-/// The maximum SMBIOS string length.
-pub const STRING_MAX_LENGTH: usize = 64;

--- a/src/protocols/smbios.rs
+++ b/src/protocols/smbios.rs
@@ -1,0 +1,19 @@
+//! SMBIOS Protocol
+//!
+//! This protocol provides the interface for managing SMBIOS records.
+
+/// The SMBIOS protocol GUID.
+pub const PROTOCOL_GUID: crate::base::Guid = crate::base::Guid::from_fields(
+    0x03583ff6,
+    0xcb36,
+    0x4940,
+    0x94,
+    0x7e,
+    &[0xb9, 0xb3, 0x9f, 0x4a, 0xfa, 0xf7],
+);
+
+/// The reserved SMBIOS handle used for automatic handle assignment.
+pub const HANDLE_PI_RESERVED: u16 = 0xfffe;
+
+/// The maximum SMBIOS string length.
+pub const STRING_MAX_LENGTH: usize = 64;


### PR DESCRIPTION
## Summary
- add the SMBIOS protocol GUID defined by [PI 1.9, Volume 5, section 6.1](https://uefi.org/specs/PI/1.9/V5_SMBIOS_Protocol.html)
- add the reserved automatic-assignment handle defined by sections 6.2 and 6.5
- expose the new SMBIOS protocol module

Tracks OpenDevicePartnership/patina#1457.

## Testing
- `cargo fmt --check` 
- `cargo test`